### PR TITLE
fix publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 
 *.test
 
+/docker/*/build/
 /out/
 inputs/


### PR DESCRIPTION
not ignoring artifacts changes the `git describe --tags` output, failing `docker save`