### PR TITLE
Informer goroutine fatal logging

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -146,7 +146,7 @@ func initServer(ctx context.Context, info witchcraft.InitInfo) (func(), error) {
 
 	queueReporter := metrics.NewQueueReporter(podInformer.Lister())
 
-	go sparkSchedulerExtender.Start(ctx)
+	sparkSchedulerExtender.Start(ctx)
 	go resourceReporter.StartReportingResourceUsage(ctx)
 	go queueReporter.StartReportingQueues(ctx)
 	go overheadComputer.Start(ctx)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -146,7 +146,7 @@ func initServer(ctx context.Context, info witchcraft.InitInfo) (func(), error) {
 
 	queueReporter := metrics.NewQueueReporter(podInformer.Lister())
 
-	sparkSchedulerExtender.Start(ctx)
+	go sparkSchedulerExtender.Start(ctx)
 	go resourceReporter.StartReportingResourceUsage(ctx)
 	go queueReporter.StartReportingQueues(ctx)
 	go overheadComputer.Start(ctx)

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -98,27 +98,28 @@ func NewExtender(
 	}
 }
 
-// Start is responsible for starting background goroutines for the SparkSchedulerExtender
+// Start is responsible for starting background tasks for the SparkSchedulerExtender
 func (s *SparkSchedulerExtender) Start(ctx context.Context) {
+	_ = wapp.RunWithFatalLogging(ctx, s.doStart)
+}
+
+func (s *SparkSchedulerExtender) doStart(ctx context.Context) error {
 	if s.checkDemandCRDExists(ctx) {
-		return
+		return nil
 	}
-	go func() {
-		_ = wapp.RunWithFatalLogging(ctx, func(ctx context.Context) error {
-			t := time.NewTicker(time.Minute)
-			defer t.Stop()
-			for {
-				select {
-				case <-ctx.Done():
-					return nil
-				case <-t.C:
-					if s.checkDemandCRDExists(ctx) {
-						return nil
-					}
-				}
+
+	t := time.NewTicker(time.Minute)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-t.C:
+			if s.checkDemandCRDExists(ctx) {
+				return nil
 			}
-		})
-	}()
+		}
+	}
 }
 
 // Predicate is responsible for returning a filtered list of nodes that qualify to schedule the pod provided in the

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -29,6 +29,7 @@ import (
 	"github.com/palantir/k8s-spark-scheduler/internal/metrics"
 	"github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+	"github.com/palantir/witchcraft-go-logging/wlog/wapp"
 	"go.uber.org/atomic"
 	"k8s.io/api/core/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -103,18 +104,20 @@ func (s *SparkSchedulerExtender) Start(ctx context.Context) {
 		return
 	}
 	go func() {
-		t := time.NewTicker(time.Minute)
-		defer t.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-t.C:
-				if s.checkDemandCRDExists(ctx) {
-					return
+		_ = wapp.RunWithFatalLogging(ctx, func(ctx context.Context) error {
+			t := time.NewTicker(time.Minute)
+			defer t.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-t.C:
+					if s.checkDemandCRDExists(ctx) {
+						return nil
+					}
 				}
 			}
-		}
+		})
 	}()
 }
 

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -100,14 +100,16 @@ func NewExtender(
 
 // Start is responsible for starting background tasks for the SparkSchedulerExtender
 func (s *SparkSchedulerExtender) Start(ctx context.Context) {
-	_ = wapp.RunWithFatalLogging(ctx, s.doStart)
+	if s.checkDemandCRDExists(ctx) {
+		return
+	}
+
+	go func() {
+		_ = wapp.RunWithFatalLogging(ctx, s.doStart)
+	}()
 }
 
 func (s *SparkSchedulerExtender) doStart(ctx context.Context) error {
-	if s.checkDemandCRDExists(ctx) {
-		return nil
-	}
-
 	t := time.NewTicker(time.Minute)
 	defer t.Stop()
 	for {


### PR DESCRIPTION
Wraps the scheduler informer and other background goroutines with the fatal logging handler to get more insights in case of panics