### PR TITLE
Add total traffic metric for each Spark application

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -17,7 +17,6 @@ package metrics
 import (
 	"context"
 	"time"
-	"math"
 
 	"github.com/palantir/pkg/metrics"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -35,7 +35,7 @@ const (
 	lifecycleAgeP50          = "foundry.spark.scheduler.pod.lifecycle.p50"
 	lifecycleCount           = "foundry.spark.scheduler.pod.lifecycle.count"
 	crossAzTraffic           = "foundry.spark.scheduler.az.cross.traffic"
-	totalTraffic        		 = "foundry.spark.scheduler.total.traffic"
+	totalTraffic             = "foundry.spark.scheduler.total.traffic"
 )
 
 const (
@@ -153,11 +153,11 @@ func ReportCrossZoneMetric(ctx context.Context, driverNodeName string, executorN
 	}
 
 	totalNumPods := len(executorNodeNames) + 1
-	czTraffic := int64(crossZoneTraffic(numPodsPerZone, totalNumPods))
-	tTraffic := int64(totalNumPods * (totalNumPods - 1) / 2)
+	crossZonePairs := int64(crossZoneTraffic(numPodsPerZone, totalNumPods))
+	totalPairs := int64(totalNumPods * (totalNumPods - 1) / 2)
 
-	metrics.FromContext(ctx).Histogram(crossAzTraffic).Update(czTraffic)
-	metrics.FromContext(ctx).Histogram(totalTraffic).Update(tTraffic)
+	metrics.FromContext(ctx).Histogram(crossAzTraffic).Update(crossZonePairs)
+	metrics.FromContext(ctx).Histogram(totalTraffic).Update(totalPairs)
 }
 
 // crossZoneTraffic calculates the total number of pairs of pods, where the 2 pods are in different zones.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -36,7 +36,7 @@ const (
 	lifecycleAgeP50          = "foundry.spark.scheduler.pod.lifecycle.p50"
 	lifecycleCount           = "foundry.spark.scheduler.pod.lifecycle.count"
 	crossAzTraffic           = "foundry.spark.scheduler.az.cross.traffic"
-	crossAzTrafficPct        = "foundry.spark.scheduler.az.cross.traffic.pct"
+	totalTraffic        		 = "foundry.spark.scheduler.total.traffic"
 )
 
 const (
@@ -155,11 +155,10 @@ func ReportCrossZoneMetric(ctx context.Context, driverNodeName string, executorN
 
 	totalNumPods := len(executorNodeNames) + 1
 	czTraffic := int64(crossZoneTraffic(numPodsPerZone, totalNumPods))
-	totalTraffic := math.Max(float64(totalNumPods * (totalNumPods - 1) / 2), 1) // no division by zero
-	czTrafficPct := 100 * czTraffic / int64(totalTraffic)
+	totalTraffic := int64(totalNumPods * (totalNumPods - 1) / 2)
 
 	metrics.FromContext(ctx).Histogram(crossAzTraffic).Update(czTraffic)
-	metrics.FromContext(ctx).Histogram(crossAzTrafficPct).Update(czTrafficPct)
+	metrics.FromContext(ctx).Histogram(totalTraffic).Update(totalTraffic)
 }
 
 // crossZoneTraffic calculates the total number of pairs of pods, where the 2 pods are in different zones.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -155,10 +155,10 @@ func ReportCrossZoneMetric(ctx context.Context, driverNodeName string, executorN
 
 	totalNumPods := len(executorNodeNames) + 1
 	czTraffic := int64(crossZoneTraffic(numPodsPerZone, totalNumPods))
-	totalTraffic := int64(totalNumPods * (totalNumPods - 1) / 2)
+	tTraffic := int64(totalNumPods * (totalNumPods - 1) / 2)
 
 	metrics.FromContext(ctx).Histogram(crossAzTraffic).Update(czTraffic)
-	metrics.FromContext(ctx).Histogram(totalTraffic).Update(totalTraffic)
+	metrics.FromContext(ctx).Histogram(totalTraffic).Update(tTraffic)
 }
 
 // crossZoneTraffic calculates the total number of pairs of pods, where the 2 pods are in different zones.


### PR DESCRIPTION
Percentage is a better indicator of cross-az traffic since it is load independent. Along with `foundry.spark.scheduler.az.cross.traffic`, `foundry.spark.scheduler.total.traffic` can be used to aggregate the percentage of cross az traffic.