### PR TITLE
[Fix] Check if resource reservation already exists before fitting driver

### DIFF
--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -197,12 +197,12 @@ func (s *SparkSchedulerExtender) selectDriverNode(ctx context.Context, driver *v
 		driverReservedNode := rr.Spec.Reservations["driver"].Node
 		for _, node := range nodeNames {
 			if driverReservedNode == node {
-				svc1log.FromContext(ctx).Info("Received request to schedule driver which already has a reservation. Returning previously reserved node...",
+				svc1log.FromContext(ctx).Info("Received request to schedule driver which already has a reservation. Returning previously reserved node.",
 					svc1log.SafeParam("driverReservedNode", driverReservedNode))
 				return driverReservedNode, success, nil
 			}
 		}
-		svc1log.FromContext(ctx).Warn("Received request to schedule driver which already has a reservation, but previously reserved node is not in list of nodes. Returning previously reserved node anyway...",
+		svc1log.FromContext(ctx).Warn("Received request to schedule driver which already has a reservation, but previously reserved node is not in list of nodes. Returning previously reserved node anyway.",
 			svc1log.SafeParam("driverReservedNode", driverReservedNode),
 			svc1log.SafeParam("nodeNames", nodeNames))
 		return driverReservedNode, success, nil

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -198,15 +198,14 @@ func (s *SparkSchedulerExtender) selectDriverNode(ctx context.Context, driver *v
 		for _, node := range nodeNames {
 			if driverReservedNode == node {
 				svc1log.FromContext(ctx).Info("Received request to schedule driver which already has a reservation. Returning previously reserved node...",
-					svc1log.SafeParam("namespace", driver.Namespace),
 					svc1log.SafeParam("driverReservedNode", driverReservedNode))
 				return driverReservedNode, success, nil
 			}
 		}
-		svc1log.FromContext(ctx).Warn("Received request to schedule driver which already has a reservation, but previously reserved node is not in list of nodes",
-			svc1log.SafeParam("namespace", driver.Namespace),
+		svc1log.FromContext(ctx).Warn("Received request to schedule driver which already has a reservation, but previously reserved node is not in list of nodes. Returning previously reserved node anyway...",
 			svc1log.SafeParam("driverReservedNode", driverReservedNode),
 			svc1log.SafeParam("nodeNames", nodeNames))
+		return driverReservedNode, success, nil
 	}
 	availableNodes, err := s.nodeLister.List(labels.Set(driver.Spec.NodeSelector).AsSelector())
 	if err != nil {


### PR DESCRIPTION
Adds a check for existing resource reservation for a driver before we attempt to schedule it in case we get a double submission from `kube-scheduler`.
We currently try to binpack a second time and only if the driver fits do we return the previous resource reservation's node, but we create a duplicate demand if the driver does not fit. This PR makes the behavior consistent between the two cases, and reduces the chances of double creating demands.