### PR TITLE
Fixes a bug in soft reservation failover for dynamic allocation

### DIFF
--- a/internal/extender/failover.go
+++ b/internal/extender/failover.go
@@ -110,13 +110,8 @@ func (r *reconciler) syncResourceReservations(ctx context.Context, sp *sparkPods
 			return nil
 		}
 
-		newRR, ok := r.resourceReservations.Get(exec.Namespace, sp.appID)
-		if !ok {
-			logRR(ctx, "could not get new resource reservation, skipping", exec.Namespace, sp.appID)
-			return nil
-		}
-		podsWithRR := make(map[string]bool, len(newRR.Status.Pods))
-		for _, podName := range newRR.Status.Pods {
+		podsWithRR := make(map[string]bool, len(rr.Status.Pods))
+		for _, podName := range rr.Status.Pods {
 			podsWithRR[podName] = true
 		}
 		for _, executor := range sp.inconsistentExecutors {


### PR DESCRIPTION
Failover now properly initializes the SoftReservationStore for all drivers that have dynamic allocation enabled and not just the ones that currently have stale executors.
PR also refactors parts of the code to separate the SoftReservation failover logic into its own method.