### PR TITLE
Fixes bug in failover where we were reading the outdated resource reservation object

### DIFF
--- a/internal/extender/failover.go
+++ b/internal/extender/failover.go
@@ -107,8 +107,13 @@ func (r *reconciler) syncResourceReservations(ctx context.Context, sp *sparkPods
 			return
 		}
 
-		podsWithRR := make(map[string]bool, len(rr.Status.Pods))
-		for _, podName := range rr.Status.Pods {
+		newRR, ok := r.resourceReservations.Get(exec.Namespace, sp.appID)
+		if !ok {
+			logRR(ctx, "could not get new resource reservation, skipping", exec.Namespace, sp.appID)
+			return
+		}
+		podsWithRR := make(map[string]bool, len(newRR.Status.Pods))
+		for _, podName := range newRR.Status.Pods {
 			podsWithRR[podName] = true
 		}
 		for _, executor := range sp.inconsistentExecutors {


### PR DESCRIPTION
Fixes a bug in failover where we were still reading the outdated resource reservation object when checking which executors need to have soft reservations.