### PR TITLE
Prioritize hosts by current usage rather than just lifetime

### DIFF
--- a/internal/extender/hostordering_test.go
+++ b/internal/extender/hostordering_test.go
@@ -1,0 +1,60 @@
+package extender
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+	"testing"
+	"time"
+)
+
+func TestNodeSorting(t *testing.T) {
+	var now = time.Unix(10000, 0)
+	var zero = *resource.NewQuantity(0, resource.BinarySI)
+	var one = *resource.NewQuantity(1, resource.BinarySI)
+	var two = *resource.NewQuantity(2, resource.BinarySI)
+
+	var oldest = scheduleContext{
+		time.Unix(0, 0),
+		zero,
+		zero,
+	}
+	var older = scheduleContext{
+		time.Unix(500, 0),
+		zero,
+		zero,
+	}
+	if compareNodes(oldest, older, now) || !compareNodes(older, oldest, now) {
+		t.Error("Old nodes should be sorted youngest first")
+	}
+	var youngNode = scheduleContext{
+		now,
+		one,
+		one,
+	}
+	if compareNodes(youngNode, oldest, now) || !compareNodes(oldest, youngNode, now) {
+		t.Error("Old nodes should be sorted before young nodes")
+	}
+	var freeMemory = scheduleContext{
+		now,
+		two,
+		zero,
+	}
+	if compareNodes(freeMemory, youngNode, now) || !compareNodes(youngNode, freeMemory, now) {
+		t.Error("Young nodes should be sorted by how much memory is available ascending")
+	}
+	var freeCpu = scheduleContext{
+		now,
+		one,
+		two,
+	}
+	if compareNodes(freeCpu, youngNode, now) || !compareNodes(youngNode, freeCpu, now) {
+		t.Error("If used memory is equal, young nodes should be sorted by how much CPU is available ascending")
+	}
+	var allThingsEqual = scheduleContext{
+		now.Add(time.Hour),
+		one,
+		one,
+	}
+	if compareNodes(allThingsEqual, youngNode, now) || !compareNodes(youngNode, allThingsEqual, now) {
+		t.Error("If all other things are equal, we should prefer scheduling on the oldest young nodes")
+	}
+}

--- a/internal/extender/hostordering_test.go
+++ b/internal/extender/hostordering_test.go
@@ -1,9 +1,10 @@
 package extender
 
 import (
-	"k8s.io/apimachinery/pkg/api/resource"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestNodeSorting(t *testing.T) {

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -296,7 +296,7 @@ const olderNodesThreshold = time.Duration(-2 * 3600 * 1000 * 1000 * 1000)
 
 // Sort older nodes before younger nodes.
 // Sort older nodes by node age ascending.
-// Sort younger nodes by resource usage descending, with RAM usage more important.
+// Sort younger nodes by available resources ascending, with RAM usage more important.
 func compareNodes(left scheduleContext, right scheduleContext, now time.Time) bool {
 	var threshold = now.Add(olderNodesThreshold)
 	if left.creationTime.Before(threshold) && right.creationTime.Before(threshold) {

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -16,7 +16,6 @@ package extender
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"sort"
 	"time"
 
@@ -31,6 +30,7 @@ import (
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"


### PR DESCRIPTION
We kill our hosts regularly, and so we would like to schedule drivers so
that they heuristically get the longest remaining lifetime. For this
reason, we currently sort our hosts purely in terms of their remaining
host lifetime.

In practice, this is demonstrably wasteful. Consider the case where we
have hosts A and B, where A has a single pod running on it and we've
just booted up host B and so it has no pods running on it. An arriving
job will be scheduled onto host B, leading to poor usage. We would
prefer to schedule the arriving job onto A as well, and be able to kill
B.

This PR takes current usage into account. First, it attempts to fill up
old nodes, regardless of their usage. For young nodes (the ones where
suitability for scheduling drivers is immaterial), we instead schedule
first based on memory (prefer the hosts with the least remaining memory)
and then CPU (prefer the hosts with the least remaining CPU).

The goal is that instead of having an even spread of partially used
hosts, we'd be able to partition into totally used hosts and mostly
unused hosts.