### PR TITLE
Prioritize hosts by current usage rather than just lifetime

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -70,6 +70,7 @@ func initServer(ctx context.Context, info witchcraft.InitInfo) (func(), error) {
 	kubeconfig.QPS = install.QPS
 	kubeconfig.Burst = install.Burst
 	instanceGroupLabel := install.InstanceGroupLabel
+	useExperimentalHostPriorities := install.UseExperimentalHostPriorities
 	if instanceGroupLabel == "" {
 		// for back-compat, as instanceGroupLabel was once hard-coded to this value
 		instanceGroupLabel = "resource_channel"
@@ -181,6 +182,7 @@ func initServer(ctx context.Context, info witchcraft.InitInfo) (func(), error) {
 		binpacker,
 		overheadComputer,
 		instanceGroupLabel,
+		useExperimentalHostPriorities,
 	)
 
 	resourceReporter := metrics.NewResourceReporter(

--- a/config/config.go
+++ b/config/config.go
@@ -20,14 +20,15 @@ import (
 
 // Install contains the install time configuration of the server and kubernetes dependency
 type Install struct {
-	config.Install     `yaml:",inline"`
-	config.Runtime     `yaml:",inline"`
-	Kubeconfig         string  `yaml:"kube-config,omitempty"`
-	FIFO               bool    `yaml:"fifo,omitempty"`
-	QPS                float32 `yaml:"qps,omitempty"`
-	Burst              int     `yaml:"burst,omitempty"`
-	BinpackAlgo        string  `yaml:"binpack,omitempty"`
-	InstanceGroupLabel string  `yaml:"instance-group-label,omitempty"`
+	config.Install                `yaml:",inline"`
+	config.Runtime                `yaml:",inline"`
+	Kubeconfig                    string  `yaml:"kube-config,omitempty"`
+	FIFO                          bool    `yaml:"fifo,omitempty"`
+	QPS                           float32 `yaml:"qps,omitempty"`
+	Burst                         int     `yaml:"burst,omitempty"`
+	BinpackAlgo                   string  `yaml:"binpack,omitempty"`
+	InstanceGroupLabel            string  `yaml:"instance-group-label,omitempty"`
+	UseExperimentalHostPriorities bool    `yaml:"use-experimental-host-priorities,omitempty"`
 
 	ResourceReservationCRDAnnotations map[string]string `yaml:"resource-reservation-crd-annotations,omitempty"`
 }

--- a/internal/extender/binpack.go
+++ b/internal/extender/binpack.go
@@ -38,7 +38,7 @@ var binpackFunctions = map[string]*Binpacker{
 func SelectBinpacker(name string) *Binpacker {
 	binpacker, ok := binpackFunctions[name]
 	if !ok {
-		return binpackFunctions[distributeEvenly]
+		return binpackFunctions[tightlyPack]
 	}
 	return binpacker
 }

--- a/internal/extender/binpack.go
+++ b/internal/extender/binpack.go
@@ -38,7 +38,7 @@ var binpackFunctions = map[string]*Binpacker{
 func SelectBinpacker(name string) *Binpacker {
 	binpacker, ok := binpackFunctions[name]
 	if !ok {
-		return binpackFunctions[tightlyPack]
+		return binpackFunctions[distributeEvenly]
 	}
 	return binpacker
 }

--- a/internal/extender/extendertest/extender_test_utils.go
+++ b/internal/extender/extendertest/extender_test_utils.go
@@ -129,6 +129,7 @@ func NewTestExtender(objects ...runtime.Object) (*Harness, error) {
 		binpacker,
 		overheadComputer,
 		instanceGroupLabel,
+		true,
 	)
 
 	unschedulablePodMarker := extender.NewUnschedulablePodMarker(

--- a/internal/extender/hostordering_test.go
+++ b/internal/extender/hostordering_test.go
@@ -15,32 +15,31 @@
 package extender
 
 import (
-	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"testing"
 
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestNodeSorting(t *testing.T) {
-	var zero = *resource.NewQuantity(0, resource.BinarySI)
 	var one = *resource.NewQuantity(1, resource.BinarySI)
 	var two = *resource.NewQuantity(2, resource.BinarySI)
 
 	var node = resources.Resources{
-		one,
-		one,
+		CPU:    one,
+		Memory: one,
 	}
 	var freeMemory = resources.Resources{
-		two,
-		zero,
+		CPU:    one,
+		Memory: two,
 	}
 
 	if lessThan(freeMemory, node) || !lessThan(node, freeMemory) {
 		t.Error("Nodes should be sorted by how much memory is available ascending")
 	}
 	var freeCPU = resources.Resources{
-		one,
-		two,
+		CPU:    two,
+		Memory: one,
 	}
 	if lessThan(freeCPU, node) || !lessThan(node, freeCPU) {
 		t.Error("If used memory is equal, nodes should be sorted by how much CPU is available ascending")

--- a/internal/extender/hostordering_test.go
+++ b/internal/extender/hostordering_test.go
@@ -15,6 +15,7 @@
 package extender
 
 import (
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -25,23 +26,23 @@ func TestNodeSorting(t *testing.T) {
 	var one = *resource.NewQuantity(1, resource.BinarySI)
 	var two = *resource.NewQuantity(2, resource.BinarySI)
 
-	var node = scheduleContext{
+	var node = resources.Resources{
 		one,
 		one,
 	}
-	var freeMemory = scheduleContext{
+	var freeMemory = resources.Resources{
 		two,
 		zero,
 	}
 
-	if compareNodes(freeMemory, node) || !compareNodes(node, freeMemory) {
+	if lessThan(freeMemory, node) || !lessThan(node, freeMemory) {
 		t.Error("Nodes should be sorted by how much memory is available ascending")
 	}
-	var freeCPU = scheduleContext{
+	var freeCPU = resources.Resources{
 		one,
 		two,
 	}
-	if compareNodes(freeCPU, node) || !compareNodes(node, freeCPU) {
+	if lessThan(freeCPU, node) || !lessThan(node, freeCPU) {
 		t.Error("If used memory is equal, nodes should be sorted by how much CPU is available ascending")
 	}
 }

--- a/internal/extender/hostordering_test.go
+++ b/internal/extender/hostordering_test.go
@@ -15,8 +15,9 @@
 package extender
 
 import (
-	"k8s.io/apimachinery/pkg/api/resource"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestNodeSorting(t *testing.T) {

--- a/internal/extender/hostordering_test.go
+++ b/internal/extender/hostordering_test.go
@@ -1,0 +1,60 @@
+package extender
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+	"testing"
+	"time"
+)
+
+func TestNodeSorting(t *testing.T) {
+	var now = time.Unix(10000, 0)
+	var zero = *resource.NewQuantity(0, resource.BinarySI)
+	var one = *resource.NewQuantity(1, resource.BinarySI)
+	var two = *resource.NewQuantity(2, resource.BinarySI)
+
+	var oldest = scheduleContext{
+		time.Unix(0, 0),
+		zero,
+		zero,
+	}
+	var older = scheduleContext{
+		time.Unix(500, 0),
+		zero,
+		zero,
+	}
+	if compareNodes(oldest, older, now) || !compareNodes(older, oldest, now) {
+		t.Error("Old nodes should be sorted youngest first")
+	}
+	var youngNode = scheduleContext{
+		now,
+		one,
+		one,
+	}
+	if compareNodes(youngNode, oldest, now) || !compareNodes(oldest, youngNode, now) {
+		t.Error("Old nodes should be sorted before young nodes")
+	}
+	var freeMemory = scheduleContext{
+		now,
+		two,
+		zero,
+	}
+	if compareNodes(freeMemory, youngNode, now) || !compareNodes(youngNode, freeMemory, now) {
+		t.Error("Young nodes should be sorted by how much memory is available ascending")
+	}
+	var freeCpu = scheduleContext{
+		now,
+		one,
+		two,
+	}
+	if compareNodes(freeCpu, youngNode, now) || !compareNodes(youngNode, freeCpu, now) {
+		t.Error("If used memory is equal, young nodes should be sorted by how much CPU is available ascending")
+	}
+	var allThingsEqual = scheduleContext{
+		now.Add(time.Hour),
+		one,
+		one,
+	}
+	if compareNodes(allThingsEqual, youngNode, now) || !compareNodes(youngNode, allThingsEqual, now) {
+		t.Error("If all other things are equal, we should prefer scheduling on the oldest young nodes")
+	}
+}

--- a/internal/extender/hostordering_test.go
+++ b/internal/extender/hostordering_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package extender
 
 import (
@@ -42,12 +56,12 @@ func TestNodeSorting(t *testing.T) {
 	if compareNodes(freeMemory, youngNode, now) || !compareNodes(youngNode, freeMemory, now) {
 		t.Error("Young nodes should be sorted by how much memory is available ascending")
 	}
-	var freeCpu = scheduleContext{
+	var freeCPU = scheduleContext{
 		now,
 		one,
 		two,
 	}
-	if compareNodes(freeCpu, youngNode, now) || !compareNodes(youngNode, freeCpu, now) {
+	if compareNodes(freeCPU, youngNode, now) || !compareNodes(youngNode, freeCPU, now) {
 		t.Error("If used memory is equal, young nodes should be sorted by how much CPU is available ascending")
 	}
 	var allThingsEqual = scheduleContext{

--- a/internal/extender/hostordering_test.go
+++ b/internal/extender/hostordering_test.go
@@ -35,13 +35,13 @@ func TestNodeSorting(t *testing.T) {
 	}
 
 	if compareNodes(freeMemory, node) || !compareNodes(node, freeMemory) {
-		t.Error("Young nodes should be sorted by how much memory is available ascending")
+		t.Error("Nodes should be sorted by how much memory is available ascending")
 	}
 	var freeCPU = scheduleContext{
 		one,
 		two,
 	}
 	if compareNodes(freeCPU, node) || !compareNodes(node, freeCPU) {
-		t.Error("If used memory is equal, young nodes should be sorted by how much CPU is available ascending")
+		t.Error("If used memory is equal, nodes should be sorted by how much CPU is available ascending")
 	}
 }

--- a/internal/extender/hostordering_test.go
+++ b/internal/extender/hostordering_test.go
@@ -15,45 +15,32 @@
 package extender
 
 import (
-	"testing"
-	"time"
-
 	"k8s.io/apimachinery/pkg/api/resource"
+	"testing"
 )
 
 func TestNodeSorting(t *testing.T) {
-	var now = time.Unix(0, 0)
 	var zero = *resource.NewQuantity(0, resource.BinarySI)
 	var one = *resource.NewQuantity(1, resource.BinarySI)
 	var two = *resource.NewQuantity(2, resource.BinarySI)
 
 	var node = scheduleContext{
-		now,
 		one,
 		one,
 	}
 	var freeMemory = scheduleContext{
-		now,
 		two,
 		zero,
 	}
-	if compareNodes(freeMemory, node, now) || !compareNodes(node, freeMemory, now) {
+
+	if compareNodes(freeMemory, node) || !compareNodes(node, freeMemory) {
 		t.Error("Young nodes should be sorted by how much memory is available ascending")
 	}
 	var freeCPU = scheduleContext{
-		now,
 		one,
 		two,
 	}
-	if compareNodes(freeCPU, node, now) || !compareNodes(node, freeCPU, now) {
+	if compareNodes(freeCPU, node) || !compareNodes(node, freeCPU) {
 		t.Error("If used memory is equal, young nodes should be sorted by how much CPU is available ascending")
-	}
-	var allThingsEqual = scheduleContext{
-		now.Add(time.Hour),
-		one,
-		one,
-	}
-	if compareNodes(allThingsEqual, node, now) || !compareNodes(node, allThingsEqual, now) {
-		t.Error("If all other things are equal, we should prefer scheduling on the oldest young nodes")
 	}
 }

--- a/internal/extender/hostordering_test.go
+++ b/internal/extender/hostordering_test.go
@@ -22,38 +22,22 @@ import (
 )
 
 func TestNodeSorting(t *testing.T) {
-	var now = time.Unix(10000, 0)
+	var now = time.Unix(0, 0)
 	var zero = *resource.NewQuantity(0, resource.BinarySI)
 	var one = *resource.NewQuantity(1, resource.BinarySI)
 	var two = *resource.NewQuantity(2, resource.BinarySI)
 
-	var oldest = scheduleContext{
-		time.Unix(0, 0),
-		zero,
-		zero,
-	}
-	var older = scheduleContext{
-		time.Unix(500, 0),
-		zero,
-		zero,
-	}
-	if compareNodes(oldest, older, now) || !compareNodes(older, oldest, now) {
-		t.Error("Old nodes should be sorted youngest first")
-	}
-	var youngNode = scheduleContext{
+	var node = scheduleContext{
 		now,
 		one,
 		one,
-	}
-	if compareNodes(youngNode, oldest, now) || !compareNodes(oldest, youngNode, now) {
-		t.Error("Old nodes should be sorted before young nodes")
 	}
 	var freeMemory = scheduleContext{
 		now,
 		two,
 		zero,
 	}
-	if compareNodes(freeMemory, youngNode, now) || !compareNodes(youngNode, freeMemory, now) {
+	if compareNodes(freeMemory, node, now) || !compareNodes(node, freeMemory, now) {
 		t.Error("Young nodes should be sorted by how much memory is available ascending")
 	}
 	var freeCPU = scheduleContext{
@@ -61,7 +45,7 @@ func TestNodeSorting(t *testing.T) {
 		one,
 		two,
 	}
-	if compareNodes(freeCPU, youngNode, now) || !compareNodes(youngNode, freeCPU, now) {
+	if compareNodes(freeCPU, node, now) || !compareNodes(node, freeCPU, now) {
 		t.Error("If used memory is equal, young nodes should be sorted by how much CPU is available ascending")
 	}
 	var allThingsEqual = scheduleContext{
@@ -69,7 +53,7 @@ func TestNodeSorting(t *testing.T) {
 		one,
 		one,
 	}
-	if compareNodes(allThingsEqual, youngNode, now) || !compareNodes(youngNode, allThingsEqual, now) {
+	if compareNodes(allThingsEqual, node, now) || !compareNodes(node, allThingsEqual, now) {
 		t.Error("If all other things are equal, we should prefer scheduling on the oldest young nodes")
 	}
 }

--- a/internal/extender/hostordering_test.go
+++ b/internal/extender/hostordering_test.go
@@ -1,9 +1,10 @@
 package extender
 
 import (
-	"k8s.io/apimachinery/pkg/api/resource"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestNodeSorting(t *testing.T) {

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -294,10 +294,7 @@ func (s *SparkSchedulerExtender) selectDriverNode(ctx context.Context, driver *v
 
 // Sort nodes by available resources ascending, with RAM usage more important.
 func compareNodes(left scheduleContext, right scheduleContext) bool {
-	if left.availableMemory.Cmp(right.availableMemory) != 0 {
-		return left.availableMemory.Cmp(right.availableMemory) == -1
-	}
-	return left.availableCPU.Cmp(right.availableCPU) == -1
+	return left.availableMemory.Cmp(right.availableMemory) == -1 || left.availableCPU.Cmp(right.availableCPU) == -1
 }
 
 type scheduleContext struct {

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -342,9 +342,9 @@ func (s *SparkSchedulerExtender) sortNodes(ctx context.Context, nodes []*v1.Node
 	}
 	var usableResources = resources.AvailableForNodes(nodes, s.usedResources(nodeNames))
 
-	var scheduleContexts = make([]scheduleContext, len(nodes))
-	for i, node := range nodes {
-		scheduleContexts[i] = scheduleContext{
+	var scheduleContexts = make(map[string]scheduleContext, len(nodes))
+	for _, node := range nodes {
+		scheduleContexts[node.Name] = scheduleContext{
 			creationTime:    node.CreationTimestamp.Time,
 			availableMemory: memory(ctx, usableResources[node.Name]),
 			availableCPU:    cpu(ctx, usableResources[node.Name]),
@@ -353,7 +353,7 @@ func (s *SparkSchedulerExtender) sortNodes(ctx context.Context, nodes []*v1.Node
 
 	var now = time.Now()
 	sort.Slice(nodes, func(i, j int) bool {
-		return compareNodes(scheduleContexts[i], scheduleContexts[j], now)
+		return compareNodes(scheduleContexts[nodes[i].Name], scheduleContexts[nodes[j].Name], now)
 	})
 }
 

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -296,7 +296,7 @@ const olderNodesThreshold = time.Duration(-2 * 3600 * 1000 * 1000 * 1000)
 
 // Sort older nodes before younger nodes.
 // Sort older nodes by node age ascending.
-// Sort younger nodes by resource usage descending, with RAM usage more important.
+// Sort younger nodes by available resources ascending, with RAM usage more important.
 func compareNodes(left scheduleContext, right scheduleContext, now time.Time) bool {
 	var threshold = now.Add(olderNodesThreshold)
 	if left.creationTime.Before(threshold) && right.creationTime.Before(threshold) {

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -303,7 +303,14 @@ func lessThan(left resources.Resources, right resources.Resources) bool {
 	return left.CPU.Cmp(right.CPU) == -1
 }
 
-func sortNodes(nodes []*v1.Node, availableResources resources.NodeGroupResources) {
+func (s *SparkSchedulerExtender) sortNodes(nodes []*v1.Node, availableResources resources.NodeGroupResources) {
+	if !s.useExperimentalHostPriorities {
+		sort.Slice(nodes, func(i, j int) bool {
+			return nodes[j].CreationTimestamp.Before(&nodes[i].CreationTimestamp)
+		})
+		return
+	}
+
 	var nodeNames = make([]string, len(nodes))
 	for i, node := range nodes {
 		nodeNames[i] = node.Name
@@ -323,7 +330,7 @@ func sortNodes(nodes []*v1.Node, availableResources resources.NodeGroupResources
 }
 
 func (s *SparkSchedulerExtender) potentialNodes(availableNodes []*v1.Node, driver *v1.Pod, nodeNames []string, availableResources resources.NodeGroupResources) (driverNodes, executorNodes []string) {
-	sortNodes(availableNodes, availableResources)
+	s.sortNodes(availableNodes, availableResources)
 	driverNodeNames := make([]string, 0, len(availableNodes))
 	executorNodeNames := make([]string, 0, len(availableNodes))
 

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -467,6 +467,11 @@ func (s *SparkSchedulerExtender) usedResources(nodeNames []string) resources.Nod
 	resourceReservations := s.resourceReservations.List()
 	usage := resources.UsageForNodes(resourceReservations)
 	usage.Add(s.softReservationStore.UsedSoftReservationResources())
+	for _, name := range nodeNames {
+		if usage[name] == nil {
+			usage[name] = resources.Zero()
+		}
+	}
 	return usage
 }
 

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -16,7 +16,6 @@ package extender
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"sort"
 	"time"
 
@@ -31,6 +30,7 @@ import (
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -294,7 +294,11 @@ func (s *SparkSchedulerExtender) selectDriverNode(ctx context.Context, driver *v
 
 // Sort nodes by available resources ascending, with RAM usage more important.
 func compareNodes(left scheduleContext, right scheduleContext) bool {
-	return left.availableMemory.Cmp(right.availableMemory) == -1 || left.availableCPU.Cmp(right.availableCPU) == -1
+	var memoryCompared = left.availableMemory.Cmp(right.availableMemory)
+	if memoryCompared != 0 {
+		return memoryCompared == -1
+	}
+	return left.availableCPU.Cmp(right.availableCPU) == -1
 }
 
 type scheduleContext struct {

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -66,11 +66,12 @@ type SparkSchedulerExtender struct {
 	demands             *cache.SafeDemandCache
 	apiExtensionsClient apiextensionsclientset.Interface
 
-	isFIFO             bool
-	binpacker          *Binpacker
-	overheadComputer   *OverheadComputer
-	lastRequest        time.Time
-	instanceGroupLabel string
+	isFIFO                        bool
+	binpacker                     *Binpacker
+	overheadComputer              *OverheadComputer
+	lastRequest                   time.Time
+	instanceGroupLabel            string
+	useExperimentalHostPriorities bool
 }
 
 // NewExtender is responsible for creating and initializing a SparkSchedulerExtender
@@ -85,19 +86,21 @@ func NewExtender(
 	isFIFO bool,
 	binpacker *Binpacker,
 	overheadComputer *OverheadComputer,
-	instanceGroupLabel string) *SparkSchedulerExtender {
+	instanceGroupLabel string,
+	useExperimentalHostPriorities bool) *SparkSchedulerExtender {
 	return &SparkSchedulerExtender{
-		nodeLister:           nodeLister,
-		podLister:            podLister,
-		resourceReservations: resourceReservations,
-		softReservationStore: softReservationStore,
-		coreClient:           coreClient,
-		demands:              demands,
-		apiExtensionsClient:  apiExtensionsClient,
-		isFIFO:               isFIFO,
-		binpacker:            binpacker,
-		overheadComputer:     overheadComputer,
-		instanceGroupLabel:   instanceGroupLabel,
+		nodeLister:                    nodeLister,
+		podLister:                     podLister,
+		resourceReservations:          resourceReservations,
+		softReservationStore:          softReservationStore,
+		coreClient:                    coreClient,
+		demands:                       demands,
+		apiExtensionsClient:           apiExtensionsClient,
+		isFIFO:                        isFIFO,
+		binpacker:                     binpacker,
+		overheadComputer:              overheadComputer,
+		instanceGroupLabel:            instanceGroupLabel,
+		useExperimentalHostPriorities: useExperimentalHostPriorities,
 	}
 }
 

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -446,11 +446,6 @@ func (s *SparkSchedulerExtender) usedResources(nodeNames []string) resources.Nod
 	resourceReservations := s.resourceReservations.List()
 	usage := resources.UsageForNodes(resourceReservations)
 	usage.Add(s.softReservationStore.UsedSoftReservationResources())
-	for _, name := range nodeNames {
-		if usage[name] == nil {
-			usage[name] = resources.Zero()
-		}
-	}
 	return usage
 }
 

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -293,7 +293,7 @@ func (s *SparkSchedulerExtender) selectDriverNode(ctx context.Context, driver *v
 }
 
 // Sort nodes by available resources ascending, with RAM usage more important.
-func compareNodes(left scheduleContext, right scheduleContext, now time.Time) bool {
+func compareNodes(left scheduleContext, right scheduleContext) bool {
 	if left.availableMemory.Cmp(right.availableMemory) != 0 {
 		return left.availableMemory.Cmp(right.availableMemory) == -1
 	}
@@ -320,9 +320,8 @@ func (s *SparkSchedulerExtender) sortNodes(nodes []*v1.Node) {
 		}
 	}
 
-	var now = time.Now()
 	sort.Slice(nodes, func(i, j int) bool {
-		return compareNodes(scheduleContexts[nodes[i].Name], scheduleContexts[nodes[j].Name], now)
+		return compareNodes(scheduleContexts[nodes[i].Name], scheduleContexts[nodes[j].Name])
 	})
 }
 

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -307,17 +307,16 @@ func compareNodes(left scheduleContext, right scheduleContext, now time.Time) bo
 		return false
 	} else if left.availableMemory.Cmp(right.availableMemory) != 0 {
 		return left.availableMemory.Cmp(right.availableMemory) == -1
-	} else if left.availableCpu.Cmp(right.availableCpu) != 0 {
-		return left.availableCpu.Cmp(right.availableCpu) == -1
-	} else {
-		return left.creationTime.Before(right.creationTime)
+	} else if left.availableCPU.Cmp(right.availableCPU) != 0 {
+		return left.availableCPU.Cmp(right.availableCPU) == -1
 	}
+	return left.creationTime.Before(right.creationTime)
 }
 
 type scheduleContext struct {
 	creationTime    time.Time
 	availableMemory resource.Quantity
-	availableCpu    resource.Quantity
+	availableCPU    resource.Quantity
 }
 
 func cpu(ctx context.Context, r *resources.Resources) resource.Quantity {
@@ -348,7 +347,7 @@ func (s *SparkSchedulerExtender) sortNodes(ctx context.Context, nodes []*v1.Node
 		scheduleContexts[i] = scheduleContext{
 			creationTime:    node.CreationTimestamp.Time,
 			availableMemory: memory(ctx, usableResources[node.Name]),
-			availableCpu:    cpu(ctx, usableResources[node.Name]),
+			availableCPU:    cpu(ctx, usableResources[node.Name]),
 		}
 	}
 


### PR DESCRIPTION
We kill our hosts regularly, and so we would like to schedule drivers so
that they heuristically get the longest remaining lifetime. For this
reason, we currently sort our hosts purely in terms of their remaining
host lifetime.
In practice, this is demonstrably wasteful. Consider the case where we
have hosts A and B, where A has a single pod running on it and we've
just booted up host B and so it has no pods running on it. An arriving
job will be scheduled onto host B, leading to poor usage. We would
prefer to schedule the arriving job onto A as well, and be able to kill
B.

This PR takes current usage into account. It fills up the most
utilized hosts first, getting to the near idle ones last.

The goal is that instead of having an even spread of partially used
hosts, we'd be able to partition into totally used hosts and mostly
unused hosts.

Also as part of this, we also change the default to tightly pack executors.
This is our internal default.

Main potential negative: The goal of this is to leave more empty hosts around.
When this happens, we strictly hope to scale down. This means that a given
arriving job will be more likely to run out of space in the cluster, and so there's
potentially more job queuing as a consequence of this. And so I'd imagine that
we'd want to roll this out on a single internal impl first to see how it goes slash
if we need to make any changes in our scaler.