### PR TITLE
Removes demand object for extra executors

### DIFF
--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -355,6 +355,8 @@ func (s *SparkSchedulerExtender) selectExecutorNode(ctx context.Context, executo
 			if err != nil {
 				return "", failureInternal, err
 			}
+			// We might have created a demand object for this executor when we were under min count, so we should remove if it exists
+			s.removeDemandIfExists(ctx, executor)
 			return node, successScheduledExtraExecutor, nil
 		}
 		return "", outcome, unboundResErr


### PR DESCRIPTION
Removes the demand object for an executor when scheduled if it exists, even if it is an extra executor, preventing demand leaks.
The scenario that this PR fixes is the following:
1. Executor doesn't fit, but application is under min executors, so we create demand in `rescheduleExecutor()`
2. We get a request later for the same executor but are now over the min, so we treat it as an extra executor. 
3. There is space for the executor this time so we allocate it, but don't delete the previous demand.