### PR TITLE
Only considers non-schedulable overhead when judging if pod exceeds cluster capacity

### DIFF
--- a/internal/extender/overhead.go
+++ b/internal/extender/overhead.go
@@ -16,13 +16,13 @@ package extender
 
 import (
 	"context"
-	"github.com/palantir/witchcraft-go-error"
 	"sort"
 	"sync"
 	"time"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"github.com/palantir/k8s-spark-scheduler/internal/cache"
+	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	"github.com/palantir/witchcraft-go-logging/wlog/wapp"
 	v1 "k8s.io/api/core/v1"
@@ -38,14 +38,14 @@ var (
 
 // OverheadComputer computes non spark scheduler managed pods total resources periodically
 type OverheadComputer struct {
-	podLister            corelisters.PodLister
-	resourceReservations *cache.ResourceReservationCache
-	softReservationStore *cache.SoftReservationStore
-	nodeLister           corelisters.NodeLister
-	latestOverhead       Overhead
-	latestNonSchedulableOverhead       Overhead
-	overheadLock         *sync.RWMutex
-	instanceGroupLabel   string
+	podLister                    corelisters.PodLister
+	resourceReservations         *cache.ResourceReservationCache
+	softReservationStore         *cache.SoftReservationStore
+	nodeLister                   corelisters.NodeLister
+	latestOverhead               Overhead
+	latestNonSchedulableOverhead Overhead
+	overheadLock                 *sync.RWMutex
+	instanceGroupLabel           string
 }
 
 // Overhead represents the overall overhead in the cluster, indexed by instance groups
@@ -88,8 +88,9 @@ func (o OverheadComputer) GetOverhead(ctx context.Context, nodes []*v1.Node) res
 	return o.getOverheadByNode(ctx, o.latestOverhead, nodes)
 }
 
-// GetOverhead fills overhead information for given nodes, and falls back to the median overhead
-// of the instance group if the node is not found
+// GetNonSchedulableOverhead fills non-schedulable overhead information for given nodes, and falls back to the median overhead
+// of the instance group if the node is not found.
+// Non-schedulable overhead is overhead by pods that are running, but do not have 'spark-scheduler' as their scheduler name.
 func (o OverheadComputer) GetNonSchedulableOverhead(ctx context.Context, nodes []*v1.Node) resources.NodeGroupResources {
 	return o.getOverheadByNode(ctx, o.latestNonSchedulableOverhead, nodes)
 }

--- a/internal/extender/overhead.go
+++ b/internal/extender/overhead.go
@@ -85,6 +85,8 @@ func (o *OverheadComputer) Start(ctx context.Context) {
 // GetOverhead fills overhead information for given nodes, and falls back to the median overhead
 // of the instance group if the node is not found
 func (o OverheadComputer) GetOverhead(ctx context.Context, nodes []*v1.Node) resources.NodeGroupResources {
+	o.overheadLock.RLock()
+	defer o.overheadLock.RUnlock()
 	return o.getOverheadByNode(ctx, o.latestOverhead, nodes)
 }
 
@@ -92,6 +94,8 @@ func (o OverheadComputer) GetOverhead(ctx context.Context, nodes []*v1.Node) res
 // of the instance group if the node is not found.
 // Non-schedulable overhead is overhead by pods that are running, but do not have 'spark-scheduler' as their scheduler name.
 func (o OverheadComputer) GetNonSchedulableOverhead(ctx context.Context, nodes []*v1.Node) resources.NodeGroupResources {
+	o.overheadLock.RLock()
+	defer o.overheadLock.RUnlock()
 	return o.getOverheadByNode(ctx, o.latestNonSchedulableOverhead, nodes)
 }
 
@@ -228,8 +232,6 @@ func (o *OverheadComputer) getPodNodeInstanceGroup(pod *v1.Pod) (string, error) 
 }
 
 func (o OverheadComputer) getOverheadByNode(ctx context.Context, overhead Overhead, nodes []*v1.Node) resources.NodeGroupResources {
-	o.overheadLock.RLock()
-	defer o.overheadLock.RUnlock()
 	res := resources.NodeGroupResources{}
 	if overhead == nil {
 		return res

--- a/internal/extender/unschedulablepods.go
+++ b/internal/extender/unschedulablepods.go
@@ -130,7 +130,7 @@ func (u *UnschedulablePodMarker) DoesPodExceedClusterCapacity(ctx context.Contex
 			svc1log.SafeParam("nodeSelector", driver.Spec.NodeSelector))
 	}
 
-	availableResources := resources.AvailableForNodes(nodes, u.overheadComputer.GetOverhead(ctx, nodes))
+	availableResources := resources.AvailableForNodes(nodes, u.overheadComputer.GetNonSchedulableOverhead(ctx, nodes))
 	applicationResources, err := sparkResources(ctx, driver)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
We sometimes incorrectly mark a pod as 'exceeding capacity' even though it should have been able to fit in the cluster. The reason for this is a fluctuation in the overhead calculation which appears to be due to the non-deterministic order with which resource reservations and executor pods are deleted.
Both the resource reservation object and the created executors have the driver as an owner. During garbage collection, the resource reservation object can get deleted while the executors stay around, which means that scheduler will count those as pods without reservations, i.e. overhead.

This PR only considers pods that do not have the `spark-scheduler` scheduler name when judging whether new pods would fit in an empty cluster.