### PR TITLE
Fixes a probable deadlock condition in the SoftReservationStore

### DIFF
--- a/internal/cache/softreservations.go
+++ b/internal/cache/softreservations.go
@@ -157,7 +157,7 @@ func (s *SoftReservationStore) ExecutorHasSoftReservation(ctx context.Context, e
 			svc1log.SafeParam("expectedLabel", SparkAppIDLabel))
 		return false
 	}
-	if sr, ok := s.GetSoftReservation(appID); ok {
+	if sr, ok := s.store[appID]; ok {
 		_, ok := sr.Reservations[executor.Name]
 		return ok
 	}


### PR DESCRIPTION
Fixes a bug in the SoftReservationStore where we were doing a recursive read lock and which could result in a deadlock.
Specifically `ExecutorHasSoftReservation` grabs a read lock but calls `GetSoftReservation` which also grabs the read lock. Given that go mutex are not reentrant, a call to `Lock()` by another goroutine in between the 2 read lock calls above would result in a deadlock.