### PR TITLE
[FIX] - Create extender.yaml ServiceAccount in spark namespace

### DIFF
--- a/examples/extender.yml
+++ b/examples/extender.yml
@@ -17,7 +17,7 @@ metadata:
   subjects:
     - kind: ServiceAccount
       name: spark-scheduler
-      namespace: default
+      namespace: spark
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole


### PR DESCRIPTION
Hello, everyone!

When trying to run the extender locally in minikube, I was getting the following error in the extender's container:

```
Error: Failed to get CRD: customresourcedefinitions.apiextensions.k8s.io "resourcereservations.sparkscheduler.palantir.com" is forbidden: User "system:serviceaccount:spark:spark-scheduler" cannot get resource "customresourcedefinitions" in API group "apiextensions.k8s.io" at the cluster scope
```

By taking a look at the `spark-scheduler`'s `ServiceAccount` definition, I saw that it was created in the `default` namespace instead of `spark`.

Thank you,
Cosmin