### PR TITLE
Introduces DemandGC 

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -159,7 +159,7 @@ func initServer(ctx context.Context, info witchcraft.InitInfo) (func(), error) {
 		return nil, err
 	}
 
-	extender.NewDemandGC(ctx, podInformerInterface, demandCache)
+	extender.StartDemandGC(ctx, podInformerInterface, demandCache)
 
 	softReservationStore := cache.NewSoftReservationStore(ctx, podInformerInterface)
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -159,6 +159,8 @@ func initServer(ctx context.Context, info witchcraft.InitInfo) (func(), error) {
 		return nil, err
 	}
 
+	extender.NewDemandGC(ctx, podInformerInterface, demandCache)
+
 	softReservationStore := cache.NewSoftReservationStore(ctx, podInformerInterface)
 
 	overheadComputer := extender.NewOverheadComputer(

--- a/internal/cache/softreservations.go
+++ b/internal/cache/softreservations.go
@@ -16,6 +16,7 @@ package cache
 
 import (
 	"context"
+	"github.com/palantir/k8s-spark-scheduler/internal/common"
 	"sync"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta1"
@@ -25,20 +26,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientcache "k8s.io/client-go/tools/cache"
-)
-
-// TODO(rkaram): Move to common place to avoid duplication without causing circular dependency
-const (
-	// SparkSchedulerName is the name of the kube-scheduler instance that talks with the extender
-	SparkSchedulerName = "spark-scheduler"
-	// SparkRoleLabel represents the label key for the spark-role of a pod
-	SparkRoleLabel = "spark-role"
-	// SparkAppIDLabel represents the label key for the spark application ID on a pod
-	SparkAppIDLabel = "spark-app-id" // TODO(onursatici): change this to a spark specific label when spark has one
-	// Driver represents the label key for a pod that identifies the pod as a spark driver
-	Driver = "driver"
-	// Executor represents the label key for a pod that identifies the pod as a spark executor
-	Executor = "executor"
 )
 
 // SoftReservationStore is an in-memory store that keeps track of soft reservations granted to extra executors for applications that support dynamic allocation
@@ -72,8 +59,8 @@ func NewSoftReservationStore(ctx context.Context, informer coreinformers.PodInfo
 		clientcache.FilteringResourceEventHandler{
 			FilterFunc: func(obj interface{}) bool {
 				if pod, ok := obj.(*v1.Pod); ok {
-					_, labelFound := pod.Labels[SparkRoleLabel]
-					if labelFound && pod.Spec.SchedulerName == SparkSchedulerName {
+					_, labelFound := pod.Labels[common.SparkRoleLabel]
+					if labelFound && pod.Spec.SchedulerName == common.SparkSchedulerName {
 						return true
 					}
 				}
@@ -150,11 +137,11 @@ func (s *SoftReservationStore) AddReservationForPod(ctx context.Context, appID s
 func (s *SoftReservationStore) ExecutorHasSoftReservation(ctx context.Context, executor *v1.Pod) bool {
 	s.storeLock.RLock()
 	defer s.storeLock.RUnlock()
-	appID, ok := executor.Labels[SparkAppIDLabel]
+	appID, ok := executor.Labels[common.SparkAppIDLabel]
 	if !ok {
 		svc1log.FromContext(ctx).Error("Cannot get SoftReservation for pod which does not have application ID label set",
 			svc1log.SafeParam("podName", executor.Name),
-			svc1log.SafeParam("expectedLabel", SparkAppIDLabel))
+			svc1log.SafeParam("expectedLabel", common.SparkAppIDLabel))
 		return false
 	}
 	if sr, ok := s.store[appID]; ok {
@@ -197,11 +184,11 @@ func (s *SoftReservationStore) onPodDeletion(obj interface{}) {
 			return
 		}
 	}
-	appID := pod.Labels[SparkAppIDLabel]
-	switch pod.Labels[SparkRoleLabel] {
-	case Driver:
+	appID := pod.Labels[common.SparkAppIDLabel]
+	switch pod.Labels[common.SparkRoleLabel] {
+	case common.Driver:
 		s.removeDriverReservation(appID)
-	case Executor:
+	case common.Executor:
 		s.removeExecutorReservation(appID, pod.Name)
 	}
 }

--- a/internal/cache/softreservations.go
+++ b/internal/cache/softreservations.go
@@ -17,6 +17,7 @@ package cache
 import (
 	"context"
 	"github.com/palantir/k8s-spark-scheduler/internal/common"
+	"github.com/palantir/k8s-spark-scheduler/internal/common/utils"
 	"sync"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta1"
@@ -57,15 +58,7 @@ func NewSoftReservationStore(ctx context.Context, informer coreinformers.PodInfo
 
 	informer.Informer().AddEventHandler(
 		clientcache.FilteringResourceEventHandler{
-			FilterFunc: func(obj interface{}) bool {
-				if pod, ok := obj.(*v1.Pod); ok {
-					_, labelFound := pod.Labels[common.SparkRoleLabel]
-					if labelFound && pod.Spec.SchedulerName == common.SparkSchedulerName {
-						return true
-					}
-				}
-				return false
-			},
+			FilterFunc: utils.IsSparkSchedulerPod,
 			Handler: clientcache.ResourceEventHandlerFuncs{
 				DeleteFunc: s.onPodDeletion,
 			},

--- a/internal/cache/softreservations.go
+++ b/internal/cache/softreservations.go
@@ -16,12 +16,12 @@ package cache
 
 import (
 	"context"
-	"github.com/palantir/k8s-spark-scheduler/internal/common"
-	"github.com/palantir/k8s-spark-scheduler/internal/common/utils"
 	"sync"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta1"
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
+	"github.com/palantir/k8s-spark-scheduler/internal/common"
+	"github.com/palantir/k8s-spark-scheduler/internal/common/utils"
 	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	v1 "k8s.io/api/core/v1"

--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+const (
+	// SparkSchedulerName is the name of the kube-scheduler instance that talks with the extender
+	SparkSchedulerName = "spark-scheduler"
+	// SparkRoleLabel represents the label key for the spark-role of a pod
+	SparkRoleLabel = "spark-role"
+	// SparkAppIDLabel represents the label key for the spark application ID on a pod
+	SparkAppIDLabel = "spark-app-id" // TODO(onursatici): change this to a spark specific label when spark has one
+	// Driver represents the label key for a pod that identifies the pod as a spark driver
+	Driver = "driver"
+	// Executor represents the label key for a pod that identifies the pod as a spark executor
+	Executor = "executor"
+)
+
+const (
+	// DriverCPU represents the key of an annotation that describes how much CPU a spark driver requires
+	DriverCPU = "spark-driver-cpu"
+	// DriverMemory represents the key of an annotation that describes how much memory a spark driver requires
+	DriverMemory = "spark-driver-mem"
+	// ExecutorCPU represents the key of an annotation that describes how much cpu a spark executor requires
+	ExecutorCPU = "spark-executor-cpu"
+	// ExecutorMemory represents the key of an annotation that describes how much memory a spark executor requires
+	ExecutorMemory = "spark-executor-mem"
+	// DynamicAllocationEnabled sets whether dynamic allocation is enabled for this spark application (false by default)
+	DynamicAllocationEnabled = "spark-dynamic-allocation-enabled"
+	// ExecutorCount represents the key of an annotation that describes how many executors a spark application requires (required if DynamicAllocationEnabled is false)
+	ExecutorCount = "spark-executor-count"
+	// DAMinExecutorCount represents the lower bound on the number of executors a spark application requires if dynamic allocation is enabled (required if DynamicAllocationEnabled is true)
+	DAMinExecutorCount = "spark-dynamic-allocation-min-executor-count"
+	// DAMaxExecutorCount represents the upper bound on the number of executors a spark application can have if dynamic allocation is enabled (required if DynamicAllocationEnabled is true)
+	DAMaxExecutorCount = "spark-dynamic-allocation-max-executor-count"
+)
+

--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -45,4 +45,3 @@ const (
 	// DAMaxExecutorCount represents the upper bound on the number of executors a spark application can have if dynamic allocation is enabled (required if DynamicAllocationEnabled is true)
 	DAMaxExecutorCount = "spark-dynamic-allocation-max-executor-count"
 )
-

--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/common/utils/pods.go
+++ b/internal/common/utils/pods.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+// IsSparkSchedulerPod returns whether the passed object is a spark application pod which has this scheduler in the scheduler spec
 func IsSparkSchedulerPod(obj interface{}) bool {
 	if pod, ok := obj.(*v1.Pod); ok {
 		_, labelFound := pod.Labels[common.SparkRoleLabel]

--- a/internal/common/utils/pods.go
+++ b/internal/common/utils/pods.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"github.com/palantir/k8s-spark-scheduler/internal/common"
+	v1 "k8s.io/api/core/v1"
+)
+
+func IsSparkSchedulerPod(obj interface{}) bool {
+	if pod, ok := obj.(*v1.Pod); ok {
+		_, labelFound := pod.Labels[common.SparkRoleLabel]
+		if labelFound && pod.Spec.SchedulerName == common.SparkSchedulerName {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -67,7 +67,7 @@ func EmitDemandCreated(ctx context.Context, demand *v1alpha1.Demand) {
 // EmitDemandDeleted logs an event when we delete a Demand object for an application. This means that we have
 // relinquished our request for more resources than are currently provisioned, either because we don't need them
 // anymore  or because we have received the resources we requested.
-func EmitDemandDeleted(ctx context.Context, demand *v1alpha1.Demand) {
+func EmitDemandDeleted(ctx context.Context, demand *v1alpha1.Demand, source string) {
 	demandAge := time.Now().UTC().Sub(demand.CreationTimestamp.UTC())
 	evt2log.FromContext(ctx).Event(demandDeleted, evt2log.Values(map[string]interface{}{
 		"instanceGroup":      demand.Spec.InstanceGroup,
@@ -75,5 +75,6 @@ func EmitDemandDeleted(ctx context.Context, demand *v1alpha1.Demand) {
 		"demandName":         demand.Name,
 		"demandAgeSeconds":   int(demandAge.Seconds()),
 		"demandCreationTime": demand.CreationTimestamp.UTC(),
+		"source":             source,
 	}))
 }

--- a/internal/extender/demand.go
+++ b/internal/extender/demand.go
@@ -121,7 +121,7 @@ func (s *SparkSchedulerExtender) removeDemandIfExists(ctx context.Context, pod *
 	if demand, ok := s.demands.Get(pod.Namespace, demandName); ok {
 		s.demands.Delete(pod.Namespace, demandName)
 		svc1log.FromContext(ctx).Info("Removed demand object because capacity exists for pod", svc1log.SafeParams(internal.DemandSafeParams(demandName, pod.Namespace)))
-		events.EmitDemandDeleted(ctx, demand)
+		events.EmitDemandDeleted(ctx, demand, "SparkSchedulerExtender")
 	}
 }
 

--- a/internal/extender/demand.go
+++ b/internal/extender/demand.go
@@ -17,14 +17,15 @@ package extender
 import (
 	"context"
 	"encoding/json"
+	"github.com/palantir/k8s-spark-scheduler/internal/common"
 
 	demandapi "github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/scaler/v1alpha1"
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"github.com/palantir/k8s-spark-scheduler/internal"
 	"github.com/palantir/k8s-spark-scheduler/internal/events"
-	werror "github.com/palantir/witchcraft-go-error"
+	"github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 )
@@ -126,9 +127,9 @@ func (s *SparkSchedulerExtender) removeDemandIfExists(ctx context.Context, pod *
 }
 
 func newDemand(pod *v1.Pod, instanceGroup string, units []demandapi.DemandUnit) (*demandapi.Demand, error) {
-	appID, ok := pod.Labels[SparkAppIDLabel]
+	appID, ok := pod.Labels[common.SparkAppIDLabel]
 	if !ok {
-		return nil, werror.Error("pod did not contain expected label for AppID", werror.SafeParam("expectedLabel", SparkAppIDLabel))
+		return nil, werror.Error("pod did not contain expected label for AppID", werror.SafeParam("expectedLabel", common.SparkAppIDLabel))
 	}
 	demandName := demandResourceName(pod)
 	return &demandapi.Demand{
@@ -136,7 +137,7 @@ func newDemand(pod *v1.Pod, instanceGroup string, units []demandapi.DemandUnit) 
 			Name:      demandName,
 			Namespace: pod.Namespace,
 			Labels: map[string]string{
-				SparkAppIDLabel: appID,
+				common.SparkAppIDLabel: appID,
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(pod, podGroupVersionKind),

--- a/internal/extender/demand_gc.go
+++ b/internal/extender/demand_gc.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extender
+
+import (
+	"context"
+
+	"github.com/palantir/k8s-spark-scheduler/internal"
+	"github.com/palantir/k8s-spark-scheduler/internal/cache"
+	"github.com/palantir/k8s-spark-scheduler/internal/events"
+	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+	v1 "k8s.io/api/core/v1"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	clientcache "k8s.io/client-go/tools/cache"
+)
+
+// DemandGC is a background pod event handler which deletes any demand we have previously created for a pod when a pod gets scheduled.
+// We also delete demands elsewhere in the extender when we schedule the pod, but those can miss some demands due to race conditions.
+type DemandGC struct {
+	demandCache *cache.SafeDemandCache
+	logger      svc1log.Logger
+}
+
+// NewDemandGC initializes the DemandGC which handles events in the background
+func NewDemandGC(ctx context.Context, podInformer coreinformers.PodInformer, demandCache *cache.SafeDemandCache) {
+	dgc := &DemandGC{
+		demandCache: demandCache,
+		logger:      svc1log.FromContext(ctx),
+	}
+
+	podInformer.Informer().AddEventHandler(
+		clientcache.FilteringResourceEventHandler{
+			FilterFunc: func(obj interface{}) bool {
+				if pod, ok := obj.(*v1.Pod); ok {
+					_, labelFound := pod.Labels[SparkRoleLabel]
+					if labelFound && pod.Spec.SchedulerName == SparkSchedulerName {
+						return true
+					}
+				}
+				return false
+			},
+			Handler: clientcache.ResourceEventHandlerFuncs{
+				UpdateFunc: dgc.onPodUpdate,
+			},
+		},
+	)
+}
+
+func (dgc *DemandGC) onPodUpdate(oldObj interface{}, newObj interface{}) {
+	oldPod, ok := oldObj.(*v1.Pod)
+	if !ok {
+		dgc.logger.Error("failed to parse oldObj as pod")
+		return
+	}
+	newPod, ok := newObj.(*v1.Pod)
+	if !ok {
+		dgc.logger.Error("failed to parse newObj as pod")
+		return
+	}
+
+	if !dgc.isPodScheduled(oldPod) && dgc.isPodScheduled(newPod) {
+		dgc.deleteDemandIfExists(newPod)
+	}
+}
+
+func (dgc *DemandGC) isPodScheduled(pod *v1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == v1.PodScheduled {
+			return true
+		}
+	}
+	return false
+}
+
+func (dgc *DemandGC) deleteDemandIfExists(pod *v1.Pod) {
+	demandName := demandResourceName(pod)
+	if demand, ok := dgc.demandCache.Get(pod.Namespace, demandName); ok {
+		// there is no harm in the demand being deleted elsewhere in between the two calls.
+		dgc.demandCache.Delete(pod.Namespace, demandName)
+		dgc.logger.Info("Removed demand object because pod is now scheduled", svc1log.SafeParams(internal.DemandSafeParams(demandName, pod.Namespace)))
+		events.EmitDemandDeleted(context.Background(), demand, "DemandGC")
+	}
+}

--- a/internal/extender/demand_gc.go
+++ b/internal/extender/demand_gc.go
@@ -44,14 +44,14 @@ import (
 // We also delete demands elsewhere in the extender when we schedule the pod, but those can miss some demands due to race conditions.
 type DemandGC struct {
 	demandCache *cache.SafeDemandCache
-	ctx 		context.Context
+	ctx         context.Context
 }
 
 // NewDemandGC initializes the DemandGC which handles events in the background
 func NewDemandGC(ctx context.Context, podInformer coreinformers.PodInformer, demandCache *cache.SafeDemandCache) {
 	dgc := &DemandGC{
 		demandCache: demandCache,
-		ctx:      	 ctx,
+		ctx:         ctx,
 	}
 
 	podInformer.Informer().AddEventHandler(

--- a/internal/extender/demand_gc.go
+++ b/internal/extender/demand_gc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/extender/demand_gc.go
+++ b/internal/extender/demand_gc.go
@@ -1,17 +1,3 @@
-// Copyright (c) 2019 Palantir Technologies. All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 // Copyright (c) 2020 Palantir Technologies. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,8 +33,8 @@ type DemandGC struct {
 	ctx         context.Context
 }
 
-// NewDemandGC initializes the DemandGC which handles events in the background
-func NewDemandGC(ctx context.Context, podInformer coreinformers.PodInformer, demandCache *cache.SafeDemandCache) {
+// StartDemandGC initializes the DemandGC which handles events in the background
+func StartDemandGC(ctx context.Context, podInformer coreinformers.PodInformer, demandCache *cache.SafeDemandCache) {
 	dgc := &DemandGC{
 		demandCache: demandCache,
 		ctx:         ctx,
@@ -57,13 +43,7 @@ func NewDemandGC(ctx context.Context, podInformer coreinformers.PodInformer, dem
 	podInformer.Informer().AddEventHandler(
 		clientcache.FilteringResourceEventHandler{
 			FilterFunc: func(obj interface{}) bool {
-				if pod, ok := obj.(*v1.Pod); ok {
-					_, labelFound := pod.Labels[SparkRoleLabel]
-					if labelFound && pod.Spec.SchedulerName == SparkSchedulerName {
-						return true
-					}
-				}
-				return false
+
 			},
 			Handler: clientcache.ResourceEventHandlerFuncs{
 				UpdateFunc: dgc.onPodUpdate,

--- a/internal/extender/demand_gc.go
+++ b/internal/extender/demand_gc.go
@@ -16,6 +16,7 @@ package extender
 
 import (
 	"context"
+	"github.com/palantir/k8s-spark-scheduler/internal/common/utils"
 
 	"github.com/palantir/k8s-spark-scheduler/internal"
 	"github.com/palantir/k8s-spark-scheduler/internal/cache"
@@ -42,9 +43,7 @@ func StartDemandGC(ctx context.Context, podInformer coreinformers.PodInformer, d
 
 	podInformer.Informer().AddEventHandler(
 		clientcache.FilteringResourceEventHandler{
-			FilterFunc: func(obj interface{}) bool {
-
-			},
+			FilterFunc: utils.IsSparkSchedulerPod,
 			Handler: clientcache.ResourceEventHandlerFuncs{
 				UpdateFunc: dgc.onPodUpdate,
 			},
@@ -71,7 +70,7 @@ func (dgc *DemandGC) onPodUpdate(oldObj interface{}, newObj interface{}) {
 
 func (dgc *DemandGC) isPodScheduled(pod *v1.Pod) bool {
 	for _, cond := range pod.Status.Conditions {
-		if cond.Type == v1.PodScheduled {
+		if cond.Type == v1.PodScheduled && cond.Status == v1.ConditionTrue {
 			return true
 		}
 	}

--- a/internal/extender/failover.go
+++ b/internal/extender/failover.go
@@ -16,7 +16,6 @@ package extender
 
 import (
 	"context"
-	"github.com/palantir/k8s-spark-scheduler/internal/common"
 	"math"
 	"sort"
 
@@ -24,9 +23,10 @@ import (
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"github.com/palantir/k8s-spark-scheduler/internal"
 	"github.com/palantir/k8s-spark-scheduler/internal/cache"
-	"github.com/palantir/witchcraft-go-error"
+	"github.com/palantir/k8s-spark-scheduler/internal/common"
+	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -156,17 +156,10 @@ func (r *reconciler) syncResourceReservations(ctx context.Context, sp *sparkPods
 
 func (r *reconciler) syncDemands(ctx context.Context, sp *sparkPods) {
 	if sp.inconsistentDriver != nil {
-		r.deleteDemandIfExists(sp.inconsistentDriver.Namespace, demandResourceName(sp.inconsistentDriver))
+		DeleteDemandIfExists(ctx, r.demands, sp.inconsistentDriver, "Reconciler")
 	}
 	for _, e := range sp.inconsistentExecutors {
-		r.deleteDemandIfExists(e.Namespace, demandResourceName(e))
-	}
-}
-
-func (r *reconciler) deleteDemandIfExists(namespace, name string) {
-	_, ok := r.demands.Get(namespace, name)
-	if ok {
-		r.demands.Delete(namespace, name)
+		DeleteDemandIfExists(ctx, r.demands, e, "Reconciler")
 	}
 }
 

--- a/internal/extender/overhead.go
+++ b/internal/extender/overhead.go
@@ -16,17 +16,17 @@ package extender
 
 import (
 	"context"
-	"github.com/palantir/k8s-spark-scheduler/internal/common"
 	"sort"
 	"sync"
 	"time"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"github.com/palantir/k8s-spark-scheduler/internal/cache"
-	"github.com/palantir/witchcraft-go-error"
+	"github.com/palantir/k8s-spark-scheduler/internal/common"
+	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	"github.com/palantir/witchcraft-go-logging/wlog/wapp"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 	corelisters "k8s.io/client-go/listers/core/v1"

--- a/internal/extender/overhead.go
+++ b/internal/extender/overhead.go
@@ -16,16 +16,17 @@ package extender
 
 import (
 	"context"
+	"github.com/palantir/k8s-spark-scheduler/internal/common"
 	"sort"
 	"sync"
 	"time"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"github.com/palantir/k8s-spark-scheduler/internal/cache"
-	werror "github.com/palantir/witchcraft-go-error"
+	"github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	"github.com/palantir/witchcraft-go-logging/wlog/wapp"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 	corelisters "k8s.io/client-go/listers/core/v1"
@@ -130,8 +131,8 @@ func (o *OverheadComputer) compute(ctx context.Context) {
 		if podsWithRRs[p.Name] {
 			continue
 		}
-		if role, ok := p.Labels[SparkRoleLabel]; ok {
-			if role == Executor && o.softReservationStore.ExecutorHasSoftReservation(ctx, p) {
+		if role, ok := p.Labels[common.SparkRoleLabel]; ok {
+			if role == common.Executor && o.softReservationStore.ExecutorHasSoftReservation(ctx, p) {
 				continue
 			}
 		}
@@ -149,7 +150,7 @@ func (o *OverheadComputer) compute(ctx context.Context) {
 		// found pod with no associated resource reservation, add to overhead
 		o.addPodResourcesToGroupResources(ctx, rawOverhead, p, instanceGroup)
 
-		if p.Spec.SchedulerName != SparkSchedulerName {
+		if p.Spec.SchedulerName != common.SparkSchedulerName {
 			// add all pods that this scheduler does not deal with to the non-schedulable overhead
 			o.addPodResourcesToGroupResources(ctx, rawNonSchedulableOverhead, p, instanceGroup)
 		}

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -16,7 +16,6 @@ package extender
 
 import (
 	"context"
-	"github.com/palantir/k8s-spark-scheduler/internal/common"
 	"time"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta1"
@@ -24,11 +23,12 @@ import (
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"github.com/palantir/k8s-spark-scheduler/internal"
 	"github.com/palantir/k8s-spark-scheduler/internal/cache"
+	"github.com/palantir/k8s-spark-scheduler/internal/common"
 	"github.com/palantir/k8s-spark-scheduler/internal/events"
 	"github.com/palantir/k8s-spark-scheduler/internal/metrics"
-	"github.com/palantir/witchcraft-go-error"
+	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/labels"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -16,6 +16,7 @@ package extender
 
 import (
 	"context"
+	"github.com/palantir/k8s-spark-scheduler/internal/common"
 	"time"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta1"
@@ -25,9 +26,9 @@ import (
 	"github.com/palantir/k8s-spark-scheduler/internal/cache"
 	"github.com/palantir/k8s-spark-scheduler/internal/events"
 	"github.com/palantir/k8s-spark-scheduler/internal/metrics"
-	werror "github.com/palantir/witchcraft-go-error"
+	"github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/labels"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -108,7 +109,7 @@ func NewExtender(
 // ExtenderArgs
 func (s *SparkSchedulerExtender) Predicate(ctx context.Context, args schedulerapi.ExtenderArgs) *schedulerapi.ExtenderFilterResult {
 	params := internal.PodSafeParams(*args.Pod)
-	role := args.Pod.Labels[SparkRoleLabel]
+	role := args.Pod.Labels[common.SparkRoleLabel]
 	ctx = svc1log.WithLoggerParams(ctx, svc1log.SafeParams(params))
 	logger := svc1log.FromContext(ctx)
 	instanceGroup, success := internal.FindInstanceGroupFromPodSpec(args.Pod.Spec, s.instanceGroupLabel)
@@ -128,7 +129,7 @@ func (s *SparkSchedulerExtender) Predicate(ctx context.Context, args schedulerap
 		return failWithMessage(ctx, args, msg)
 	}
 
-	nodeName, outcome, err := s.selectNode(ctx, args.Pod.Labels[SparkRoleLabel], args.Pod, *args.NodeNames)
+	nodeName, outcome, err := s.selectNode(ctx, args.Pod.Labels[common.SparkRoleLabel], args.Pod, *args.NodeNames)
 	timer.Mark(ctx, role, outcome)
 	if err != nil {
 		if outcome == failureInternal {
@@ -139,7 +140,7 @@ func (s *SparkSchedulerExtender) Predicate(ctx context.Context, args schedulerap
 		return failWithMessage(ctx, args, err.Error())
 	}
 
-	if role == Driver {
+	if role == common.Driver {
 		appResources, err := sparkResources(ctx, args.Pod)
 		if err != nil {
 			logger.Error("internal error scheduling pod", svc1log.Stacktrace(err))
@@ -148,7 +149,7 @@ func (s *SparkSchedulerExtender) Predicate(ctx context.Context, args schedulerap
 		events.EmitApplicationScheduled(
 			ctx,
 			instanceGroup,
-			args.Pod.Labels[SparkAppIDLabel],
+			args.Pod.Labels[common.SparkAppIDLabel],
 			*args.Pod,
 			appResources.driverResources,
 			appResources.executorResources,
@@ -183,9 +184,9 @@ func (s *SparkSchedulerExtender) reconcileIfNeeded(ctx context.Context, timer *m
 
 func (s *SparkSchedulerExtender) selectNode(ctx context.Context, role string, pod *v1.Pod, nodeNames []string) (string, string, error) {
 	switch role {
-	case Driver:
+	case common.Driver:
 		return s.selectDriverNode(ctx, pod, nodeNames)
-	case Executor:
+	case common.Executor:
 		return s.selectExecutorNode(ctx, pod, nodeNames)
 	default:
 		return "", failureNonSparkPod, werror.Error("can not schedule non spark pod")
@@ -227,7 +228,7 @@ func (s *SparkSchedulerExtender) fitEarlierDrivers(
 }
 
 func (s *SparkSchedulerExtender) selectDriverNode(ctx context.Context, driver *v1.Pod, nodeNames []string) (string, string, error) {
-	if rr, ok := s.resourceReservations.Get(driver.Namespace, driver.Labels[SparkAppIDLabel]); ok {
+	if rr, ok := s.resourceReservations.Get(driver.Namespace, driver.Labels[common.SparkAppIDLabel]); ok {
 		driverReservedNode := rr.Spec.Reservations["driver"].Node
 		for _, node := range nodeNames {
 			if driverReservedNode == node {
@@ -296,7 +297,7 @@ func (s *SparkSchedulerExtender) selectDriverNode(ctx context.Context, driver *v
 	reservedDriverNode, outcome, err := s.createResourceReservations(ctx, driver, applicationResources, driverNode, executorNodes)
 	if outcome == success && applicationResources.maxExecutorCount > applicationResources.minExecutorCount {
 		// only create soft reservations for applications which can request extra executors
-		s.softReservationStore.CreateSoftReservationIfNotExists(driver.Labels[SparkAppIDLabel])
+		s.softReservationStore.CreateSoftReservationIfNotExists(driver.Labels[common.SparkAppIDLabel])
 	}
 	return reservedDriverNode, outcome, err
 }
@@ -323,14 +324,14 @@ func (s *SparkSchedulerExtender) potentialNodes(availableNodesSchedulingMetadata
 }
 
 func (s *SparkSchedulerExtender) selectExecutorNode(ctx context.Context, executor *v1.Pod, nodeNames []string) (string, string, error) {
-	resourceReservation, ok := s.resourceReservations.Get(executor.Namespace, executor.Labels[SparkAppIDLabel])
+	resourceReservation, ok := s.resourceReservations.Get(executor.Namespace, executor.Labels[common.SparkAppIDLabel])
 	if !ok {
 		return "", failureInternal, werror.Error("failed to get resource reservations")
 	}
 	unboundReservations, outcome, unboundResErr := s.findUnboundReservations(ctx, executor, resourceReservation)
 	if unboundResErr != nil {
 		extraExecutorCount := 0
-		if sr, ok := s.softReservationStore.GetSoftReservation(executor.Labels[SparkAppIDLabel]); ok {
+		if sr, ok := s.softReservationStore.GetSoftReservation(executor.Labels[common.SparkAppIDLabel]); ok {
 			extraExecutorCount = len(sr.Reservations)
 		}
 		driver, err := s.podLister.getDriverPod(ctx, executor)
@@ -355,7 +356,7 @@ func (s *SparkSchedulerExtender) selectExecutorNode(ctx context.Context, executo
 				CPU:    sparkResources.executorResources.CPU,
 				Memory: sparkResources.executorResources.Memory,
 			}
-			err = s.softReservationStore.AddReservationForPod(ctx, driver.Labels[SparkAppIDLabel], executor.Name, softReservation)
+			err = s.softReservationStore.AddReservationForPod(ctx, driver.Labels[common.SparkAppIDLabel], executor.Name, softReservation)
 			if err != nil {
 				return "", failureInternal, err
 			}
@@ -486,7 +487,7 @@ func (s *SparkSchedulerExtender) findUnboundReservations(ctx context.Context, ex
 	}
 	// No unbound reservations exist, so iterate over existing reservations to see if any of the reserved pods are dead.
 	// Spark will recreate lost executors, so the replacement executors should be placed on the reserved spaces of dead executors.
-	selector := labels.Set(map[string]string{SparkAppIDLabel: executor.Labels[SparkAppIDLabel]}).AsSelector()
+	selector := labels.Set(map[string]string{common.SparkAppIDLabel: executor.Labels[common.SparkAppIDLabel]}).AsSelector()
 	pods, err := s.podLister.Pods(executor.Namespace).List(selector)
 	if err != nil {
 		return nil, failureInternal, werror.Wrap(err, "failed to list pods")

--- a/internal/extender/resourcereservations.go
+++ b/internal/extender/resourcereservations.go
@@ -16,10 +16,11 @@ package extender
 
 import (
 	"fmt"
+	"github.com/palantir/k8s-spark-scheduler/internal/common"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta1"
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -41,11 +42,11 @@ func newResourceReservation(driverNode string, executorNodes []string, driver *v
 	}
 	return &v1beta1.ResourceReservation{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            driver.Labels[SparkAppIDLabel],
+			Name:            driver.Labels[common.SparkAppIDLabel],
 			Namespace:       driver.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(driver, podGroupVersionKind)},
 			Labels: map[string]string{
-				v1beta1.AppIDLabel: driver.Labels[SparkAppIDLabel],
+				v1beta1.AppIDLabel: driver.Labels[common.SparkAppIDLabel],
 			},
 		},
 		Spec: v1beta1.ResourceReservationSpec{

--- a/internal/extender/resourcereservations.go
+++ b/internal/extender/resourcereservations.go
@@ -16,11 +16,11 @@ package extender
 
 import (
 	"fmt"
-	"github.com/palantir/k8s-spark-scheduler/internal/common"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta1"
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
-	"k8s.io/api/core/v1"
+	"github.com/palantir/k8s-spark-scheduler/internal/common"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/internal/extender/sparkpods.go
+++ b/internal/extender/sparkpods.go
@@ -17,47 +17,16 @@ package extender
 import (
 	"context"
 	"fmt"
+	"github.com/palantir/k8s-spark-scheduler/internal/common"
 	"sort"
 	"strconv"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"github.com/palantir/k8s-spark-scheduler/internal"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 	corelisters "k8s.io/client-go/listers/core/v1"
-)
-
-const (
-	// SparkSchedulerName is the name of the kube-scheduler instance that talks with the extender
-	SparkSchedulerName = "spark-scheduler"
-	// SparkRoleLabel represents the label key for the spark-role of a pod
-	SparkRoleLabel = "spark-role"
-	// SparkAppIDLabel represents the label key for the spark application ID on a pod
-	SparkAppIDLabel = "spark-app-id" // TODO(onursatici): change this to a spark specific label when spark has one
-	// Driver represents the label key for a pod that identifies the pod as a spark driver
-	Driver = "driver"
-	// Executor represents the label key for a pod that identifies the pod as a spark executor
-	Executor = "executor"
-)
-
-const (
-	// DriverCPU represents the key of an annotation that describes how much CPU a spark driver requires
-	DriverCPU = "spark-driver-cpu"
-	// DriverMemory represents the key of an annotation that describes how much memory a spark driver requires
-	DriverMemory = "spark-driver-mem"
-	// ExecutorCPU represents the key of an annotation that describes how much cpu a spark executor requires
-	ExecutorCPU = "spark-executor-cpu"
-	// ExecutorMemory represents the key of an annotation that describes how much memory a spark executor requires
-	ExecutorMemory = "spark-executor-mem"
-	// DynamicAllocationEnabled sets whether dynamic allocation is enabled for this spark application (false by default)
-	DynamicAllocationEnabled = "spark-dynamic-allocation-enabled"
-	// ExecutorCount represents the key of an annotation that describes how many executors a spark application requires (required if DynamicAllocationEnabled is false)
-	ExecutorCount = "spark-executor-count"
-	// DAMinExecutorCount represents the lower bound on the number of executors a spark application requires if dynamic allocation is enabled (required if DynamicAllocationEnabled is true)
-	DAMinExecutorCount = "spark-dynamic-allocation-min-executor-count"
-	// DAMaxExecutorCount represents the upper bound on the number of executors a spark application can have if dynamic allocation is enabled (required if DynamicAllocationEnabled is true)
-	DAMaxExecutorCount = "spark-dynamic-allocation-max-executor-count"
 )
 
 type sparkApplicationResources struct {
@@ -80,7 +49,7 @@ func NewSparkPodLister(delegate corelisters.PodLister, instanceGroupLabel string
 
 // ListEarlierDrivers lists earlier driver than the given driver that has the same node selectors
 func (s SparkPodLister) ListEarlierDrivers(driver *v1.Pod) ([]*v1.Pod, error) {
-	selector := labels.Set(map[string]string{SparkRoleLabel: Driver}).AsSelector()
+	selector := labels.Set(map[string]string{common.SparkRoleLabel: common.Driver}).AsSelector()
 	drivers, err := s.List(selector)
 	if err != nil {
 		return nil, err
@@ -110,7 +79,7 @@ func filterToEarliestAndSort(driver *v1.Pod, allDrivers []*v1.Pod, instanceGroup
 func sparkResources(ctx context.Context, pod *v1.Pod) (*sparkApplicationResources, error) {
 	parsedResources := map[string]resource.Quantity{}
 	dynamicAllocationEnabled := false
-	if daLabel, ok := pod.Annotations[DynamicAllocationEnabled]; ok {
+	if daLabel, ok := pod.Annotations[common.DynamicAllocationEnabled]; ok {
 		da, err := strconv.ParseBool(daLabel)
 		if err != nil {
 			return nil, fmt.Errorf("annotation DynamicAllocationEnabled could not be parsed as a boolean")
@@ -118,15 +87,15 @@ func sparkResources(ctx context.Context, pod *v1.Pod) (*sparkApplicationResource
 		dynamicAllocationEnabled = da
 	}
 
-	for _, a := range []string{DriverCPU, DriverMemory, ExecutorCPU, ExecutorMemory, ExecutorCount, DAMinExecutorCount, DAMaxExecutorCount} {
+	for _, a := range []string{common.DriverCPU, common.DriverMemory, common.ExecutorCPU, common.ExecutorMemory, common.ExecutorCount, common.DAMinExecutorCount, common.DAMaxExecutorCount} {
 		value, ok := pod.Annotations[a]
 		if !ok {
 			switch {
-			case dynamicAllocationEnabled == false && a == ExecutorCount:
+			case dynamicAllocationEnabled == false && a == common.ExecutorCount:
 				return nil, fmt.Errorf("annotation ExecutorCount is required when DynamicAllocationEnabled is false")
-			case dynamicAllocationEnabled == true && (a == DAMinExecutorCount || a == DAMaxExecutorCount):
+			case dynamicAllocationEnabled == true && (a == common.DAMinExecutorCount || a == common.DAMaxExecutorCount):
 				return nil, fmt.Errorf("annotation %v is required when DynamicAllocationEnabled is true", a)
-			case a == ExecutorCount || a == DAMinExecutorCount || a == DAMaxExecutorCount:
+			case a == common.ExecutorCount || a == common.DAMinExecutorCount || a == common.DAMaxExecutorCount:
 				continue
 			}
 			return nil, fmt.Errorf("annotation %v is missing from driver", a)
@@ -142,23 +111,23 @@ func sparkResources(ctx context.Context, pod *v1.Pod) (*sparkApplicationResource
 	var maxExecutorCount int
 	if dynamicAllocationEnabled {
 		// justification for casting to int from int64: executor count is small (<1000)
-		parsedMinExecutorCount := parsedResources[DAMinExecutorCount]
-		parsedMaxExecutorCount := parsedResources[DAMaxExecutorCount]
+		parsedMinExecutorCount := parsedResources[common.DAMinExecutorCount]
+		parsedMaxExecutorCount := parsedResources[common.DAMaxExecutorCount]
 		minExecutorCount = int(parsedMinExecutorCount.Value())
 		maxExecutorCount = int(parsedMaxExecutorCount.Value())
 	} else {
-		parsedExecutorCount := parsedResources[ExecutorCount]
+		parsedExecutorCount := parsedResources[common.ExecutorCount]
 		minExecutorCount = int(parsedExecutorCount.Value())
 		maxExecutorCount = int(parsedExecutorCount.Value())
 	}
 
 	driverResources := &resources.Resources{
-		CPU:    parsedResources[DriverCPU],
-		Memory: parsedResources[DriverMemory],
+		CPU:    parsedResources[common.DriverCPU],
+		Memory: parsedResources[common.DriverMemory],
 	}
 	executorResources := &resources.Resources{
-		CPU:    parsedResources[ExecutorCPU],
-		Memory: parsedResources[ExecutorMemory],
+		CPU:    parsedResources[common.ExecutorCPU],
+		Memory: parsedResources[common.ExecutorMemory],
 	}
 	return &sparkApplicationResources{driverResources, executorResources, minExecutorCount, maxExecutorCount}, nil
 }
@@ -173,7 +142,7 @@ func sparkResourceUsage(driverResources, executorResources *resources.Resources,
 }
 
 func (s SparkPodLister) getDriverPod(ctx context.Context, executor *v1.Pod) (*v1.Pod, error) {
-	selector := labels.Set(map[string]string{SparkAppIDLabel: executor.Labels[SparkAppIDLabel], SparkRoleLabel: Driver}).AsSelector()
+	selector := labels.Set(map[string]string{common.SparkAppIDLabel: executor.Labels[common.SparkAppIDLabel], common.SparkRoleLabel: common.Driver}).AsSelector()
 	driver, err := s.Pods(executor.Namespace).List(selector)
 	if err != nil || len(driver) != 1 {
 		return nil, err

--- a/internal/extender/sparkpods.go
+++ b/internal/extender/sparkpods.go
@@ -17,13 +17,13 @@ package extender
 import (
 	"context"
 	"fmt"
-	"github.com/palantir/k8s-spark-scheduler/internal/common"
 	"sort"
 	"strconv"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"github.com/palantir/k8s-spark-scheduler/internal"
-	"k8s.io/api/core/v1"
+	"github.com/palantir/k8s-spark-scheduler/internal/common"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 	corelisters "k8s.io/client-go/listers/core/v1"

--- a/internal/extender/sparkpods_test.go
+++ b/internal/extender/sparkpods_test.go
@@ -16,12 +16,13 @@ package extender
 
 import (
 	"context"
+	"github.com/palantir/k8s-spark-scheduler/internal/common"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -44,11 +45,11 @@ func TestSparkResources(t *testing.T) {
 		pod: v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					DriverCPU:      "1",
-					DriverMemory:   "2432Mi",
-					ExecutorCPU:    "2",
-					ExecutorMemory: "6758Mi",
-					ExecutorCount:  "2",
+					common.DriverCPU:      "1",
+					common.DriverMemory:   "2432Mi",
+					common.ExecutorCPU:    "2",
+					common.ExecutorMemory: "6758Mi",
+					common.ExecutorCount:  "2",
 				},
 			},
 		},
@@ -63,13 +64,13 @@ func TestSparkResources(t *testing.T) {
 		pod: v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					DriverCPU:                "1",
-					DriverMemory:             "2432Mi",
-					ExecutorCPU:              "2",
-					ExecutorMemory:           "6758Mi",
-					DynamicAllocationEnabled: "true",
-					DAMinExecutorCount:       "2",
-					DAMaxExecutorCount:       "5",
+					common.DriverCPU:                "1",
+					common.DriverMemory:             "2432Mi",
+					common.ExecutorCPU:              "2",
+					common.ExecutorMemory:           "6758Mi",
+					common.DynamicAllocationEnabled: "true",
+					common.DAMinExecutorCount:       "2",
+					common.DAMaxExecutorCount:       "5",
 				},
 			},
 		},

--- a/internal/extender/sparkpods_test.go
+++ b/internal/extender/sparkpods_test.go
@@ -16,13 +16,13 @@ package extender
 
 import (
 	"context"
-	"github.com/palantir/k8s-spark-scheduler/internal/common"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
-	"k8s.io/api/core/v1"
+	"github.com/palantir/k8s-spark-scheduler/internal/common"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/internal/extender/unschedulablepods.go
+++ b/internal/extender/unschedulablepods.go
@@ -16,13 +16,13 @@ package extender
 
 import (
 	"context"
-	"github.com/palantir/k8s-spark-scheduler/internal/common"
 	"time"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
+	"github.com/palantir/k8s-spark-scheduler/internal/common"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	"github.com/palantir/witchcraft-go-logging/wlog/wapp"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"

--- a/internal/extender/unschedulablepods.go
+++ b/internal/extender/unschedulablepods.go
@@ -16,12 +16,13 @@ package extender
 
 import (
 	"context"
+	"github.com/palantir/k8s-spark-scheduler/internal/common"
 	"time"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	"github.com/palantir/witchcraft-go-logging/wlog/wapp"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
@@ -87,10 +88,10 @@ func (u *UnschedulablePodMarker) scanForUnschedulablePods(ctx context.Context) {
 	}
 	now := time.Now()
 	for _, pod := range pods {
-		if pod.Spec.SchedulerName == SparkSchedulerName &&
+		if pod.Spec.SchedulerName == common.SparkSchedulerName &&
 			len(pod.Spec.NodeName) == 0 &&
 			pod.DeletionTimestamp == nil &&
-			pod.Labels[SparkRoleLabel] == Driver &&
+			pod.Labels[common.SparkRoleLabel] == common.Driver &&
 			pod.CreationTimestamp.Time.Add(unschedulableInClusterThreshold).Before(now) {
 
 			ctx = svc1log.WithLoggerParams(


### PR DESCRIPTION
This PR introduces a background pod event handler which deletes any demand we have previously created for a pod when it gets scheduled.
This is supposed to catch any demands that were not deleted by the extender, and we can later on centralise all demand deletions in here.