### PR TITLE
Refactors Reservation creations into a ResourceReservationManager

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,12 +149,12 @@ release-requires-filter: &release-requires-filter
     tags:
       only: /^v?[0-9]+(\.[0-9]+)+(-rc[0-9]+)?$/
     branches:
-      only: /rk\/reservations_refactor/
+      ignore: /.*/
 
 # Filter that matches only the "master" branch. Used for jobs that publish snapshots.
 master-requires-filter: &master-requires-filter
   requires: *requires_jobs
-  filters: { tags: { ignore: /.*/ }, branches: { only: /rk\/reservations_refactor/ } }
+  filters: { tags: { ignore: /.*/ }, branches: { only: /master/ } }
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,12 +149,12 @@ release-requires-filter: &release-requires-filter
     tags:
       only: /^v?[0-9]+(\.[0-9]+)+(-rc[0-9]+)?$/
     branches:
-      ignore: /.*/
+      only: /rk\/reservations_refactor/
 
 # Filter that matches only the "master" branch. Used for jobs that publish snapshots.
 master-requires-filter: &master-requires-filter
   requires: *requires_jobs
-  filters: { tags: { ignore: /.*/ }, branches: { only: /master/ } }
+  filters: { tags: { ignore: /.*/ }, branches: { only: /rk\/reservations_refactor/ } }
 
 workflows:
   version: 2

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -180,6 +180,8 @@ func initServer(ctx context.Context, info witchcraft.InitInfo) (func(), error) {
 	sparkSchedulerExtender := extender.NewExtender(
 		nodeLister,
 		sparkPodLister,
+		resourceReservationCache,
+		softReservationStore,
 		resourceReservationManager,
 		kubeClient.CoreV1(),
 		demandCache,

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -163,6 +163,9 @@ func initServer(ctx context.Context, info witchcraft.InitInfo) (func(), error) {
 
 	softReservationStore := cache.NewSoftReservationStore(ctx, podInformerInterface)
 
+	sparkPodLister := extender.NewSparkPodLister(podLister, instanceGroupLabel)
+	resourceReservationManager := extender.NewResourceReservationManager(resourceReservationCache, softReservationStore, sparkPodLister)
+
 	overheadComputer := extender.NewOverheadComputer(
 		ctx,
 		podLister,
@@ -176,9 +179,8 @@ func initServer(ctx context.Context, info witchcraft.InitInfo) (func(), error) {
 
 	sparkSchedulerExtender := extender.NewExtender(
 		nodeLister,
-		extender.NewSparkPodLister(podLister, instanceGroupLabel),
-		resourceReservationCache,
-		softReservationStore,
+		sparkPodLister,
+		resourceReservationManager,
 		kubeClient.CoreV1(),
 		demandCache,
 		apiExtensionsClient,

--- a/internal/cache/softreservations.go
+++ b/internal/cache/softreservations.go
@@ -132,7 +132,6 @@ func (s *SoftReservationStore) ExecutorHasSoftReservation(ctx context.Context, e
 	return ok
 }
 
-
 // GetExecutorSoftReservation returns the Reservation object associated with this executor if it exists.
 func (s *SoftReservationStore) GetExecutorSoftReservation(ctx context.Context, executor *v1.Pod) (*v1beta1.Reservation, bool) {
 	s.storeLock.RLock()

--- a/internal/cache/softreservations.go
+++ b/internal/cache/softreservations.go
@@ -128,6 +128,13 @@ func (s *SoftReservationStore) AddReservationForPod(ctx context.Context, appID s
 
 // ExecutorHasSoftReservation returns true when the passed executor pod currently has a SoftReservation, false otherwise.
 func (s *SoftReservationStore) ExecutorHasSoftReservation(ctx context.Context, executor *v1.Pod) bool {
+	_, ok := s.GetExecutorSoftReservation(ctx, executor)
+	return ok
+}
+
+
+// GetExecutorSoftReservation returns the Reservation object associated with this executor if it exists.
+func (s *SoftReservationStore) GetExecutorSoftReservation(ctx context.Context, executor *v1.Pod) (*v1beta1.Reservation, bool) {
 	s.storeLock.RLock()
 	defer s.storeLock.RUnlock()
 	appID, ok := executor.Labels[common.SparkAppIDLabel]
@@ -135,13 +142,14 @@ func (s *SoftReservationStore) ExecutorHasSoftReservation(ctx context.Context, e
 		svc1log.FromContext(ctx).Error("Cannot get SoftReservation for pod which does not have application ID label set",
 			svc1log.SafeParam("podName", executor.Name),
 			svc1log.SafeParam("expectedLabel", common.SparkAppIDLabel))
-		return false
+		return nil, false
 	}
 	if sr, ok := s.store[appID]; ok {
-		_, ok := sr.Reservations[executor.Name]
-		return ok
+		if res, ok := sr.Reservations[executor.Name]; ok {
+			return res.DeepCopy(), true
+		}
 	}
-	return false
+	return nil, false
 }
 
 // UsedSoftReservationResources returns SoftReservation usage by node.

--- a/internal/common/utils/pods.go
+++ b/internal/common/utils/pods.go
@@ -29,3 +29,12 @@ func IsSparkSchedulerPod(obj interface{}) bool {
 	}
 	return false
 }
+
+// IsPodTerminated returns whether the pod is considered to be terminated
+func IsPodTerminated(pod *v1.Pod) bool {
+	allTerminated := len(pod.Status.ContainerStatuses) > 0
+	for _, status := range pod.Status.ContainerStatuses {
+		allTerminated = allTerminated && status.State.Terminated != nil
+	}
+	return allTerminated
+}

--- a/internal/common/utils/sets.go
+++ b/internal/common/utils/sets.go
@@ -49,7 +49,7 @@ func (s *StringSet) Size() int {
 // ToSlice returns all the elements of StringSet as a slice of strings
 func (s *StringSet) ToSlice() []string {
 	result := make([]string, len(s.elements))
-	for e, _ := range s.elements {
+	for e := range s.elements {
 		result = append(result, e)
 	}
 	return result

--- a/internal/common/utils/sets.go
+++ b/internal/common/utils/sets.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+// StringSet is a non-thread safe set of unique strings
+type StringSet struct {
+	elements map[string]bool
+}
+
+// NewStringSet constructs and returns a StringSet
+func NewStringSet(size int) *StringSet {
+	return &StringSet{
+		elements: make(map[string]bool, size),
+	}
+}
+
+// Add adds the string e to the StringSet if it is not already there
+func (s *StringSet) Add(e string) {
+	s.elements[e] = true
+}
+
+// Remove removes the string e from the StringSet if it is there. It is a no-op otherwise
+func (s *StringSet) Remove(e string) {
+	delete(s.elements, e)
+}
+
+// Contains returns true if the string e is in the StringSet, false otherwise
+func (s *StringSet) Contains(e string) bool {
+	return s.elements[e]
+}
+
+// Size returns the number of elements in the StringSet
+func (s *StringSet) Size() int {
+	return len(s.elements)
+}
+
+// ToSlice returns all the elements of StringSet as a slice of strings
+func (s *StringSet) ToSlice() []string {
+	result := make([]string, len(s.elements))
+	for e, _ := range s.elements {
+		result = append(result, e)
+	}
+	return result
+}

--- a/internal/common/utils/sets.go
+++ b/internal/common/utils/sets.go
@@ -15,41 +15,44 @@
 package utils
 
 // StringSet is a non-thread safe set of unique strings
-type StringSet struct {
-	elements map[string]bool
-}
+type StringSet map[string]bool
 
 // NewStringSet constructs and returns a StringSet
-func NewStringSet(size int) *StringSet {
-	return &StringSet{
-		elements: make(map[string]bool, size),
-	}
+func NewStringSet(size int) StringSet {
+	return make(StringSet, size)
 }
 
 // Add adds the string e to the StringSet if it is not already there
-func (s *StringSet) Add(e string) {
-	s.elements[e] = true
+func (s StringSet) Add(e string) {
+	s[e] = true
+}
+
+// AddAll adds the strings in es to the StringSet if they are not already there
+func (s StringSet) AddAll(es []string) {
+	for _, e := range es {
+		s[e] = true
+	}
 }
 
 // Remove removes the string e from the StringSet if it is there. It is a no-op otherwise
-func (s *StringSet) Remove(e string) {
-	delete(s.elements, e)
+func (s StringSet) Remove(e string) {
+	delete(s, e)
 }
 
 // Contains returns true if the string e is in the StringSet, false otherwise
-func (s *StringSet) Contains(e string) bool {
-	return s.elements[e]
+func (s StringSet) Contains(e string) bool {
+	return s[e]
 }
 
 // Size returns the number of elements in the StringSet
-func (s *StringSet) Size() int {
-	return len(s.elements)
+func (s StringSet) Size() int {
+	return len(s)
 }
 
 // ToSlice returns all the elements of StringSet as a slice of strings
-func (s *StringSet) ToSlice() []string {
-	result := make([]string, len(s.elements))
-	for e := range s.elements {
+func (s StringSet) ToSlice() []string {
+	result := make([]string, s.Size())
+	for e := range s {
 		result = append(result, e)
 	}
 	return result

--- a/internal/extender/extendertest/extender_test_utils.go
+++ b/internal/extender/extendertest/extender_test_utils.go
@@ -110,6 +110,9 @@ func NewTestExtender(objects ...runtime.Object) (*Harness, error) {
 	)
 	softReservationStore := sscache.NewSoftReservationStore(ctx, podInformerInterface)
 
+	sparkPodLister := extender.NewSparkPodLister(podLister, instanceGroupLabel)
+	resourceReservationManager := extender.NewResourceReservationManager(resourceReservationCache, softReservationStore, sparkPodLister)
+
 	overheadComputer := extender.NewOverheadComputer(
 		ctx,
 		podLister,
@@ -124,9 +127,10 @@ func NewTestExtender(objects ...runtime.Object) (*Harness, error) {
 
 	sparkSchedulerExtender := extender.NewExtender(
 		nodeLister,
-		extender.NewSparkPodLister(podLister, instanceGroupLabel),
+		sparkPodLister,
 		resourceReservationCache,
 		softReservationStore,
+		resourceReservationManager,
 		fakeKubeClient.CoreV1(),
 		demandCache,
 		fakeAPIExtensionsClient,

--- a/internal/extender/extendertest/extender_test_utils.go
+++ b/internal/extender/extendertest/extender_test_utils.go
@@ -166,11 +166,20 @@ func NewTestExtender(objects ...runtime.Object) (*Harness, error) {
 }
 
 // Schedule calls the extender's Predicate method for the given pod and nodes
-func (h *Harness) Schedule(pod v1.Pod, nodeNames []string) *schedulerapi.ExtenderFilterResult {
-	return h.Extender.Predicate(h.Ctx, schedulerapi.ExtenderArgs{
+func (h *Harness) Schedule(t *testing.T, pod v1.Pod, nodeNames []string) *schedulerapi.ExtenderFilterResult {
+	extenderPredicateResult := h.Extender.Predicate(h.Ctx, schedulerapi.ExtenderArgs{
 		Pod:       &pod,
 		NodeNames: &nodeNames,
 	})
+	if extenderPredicateResult.NodeNames != nil && len(*extenderPredicateResult.NodeNames) > 0 {
+		pod.Spec.NodeName = (*extenderPredicateResult.NodeNames)[0]
+		pod.Status.Phase = v1.PodRunning
+		err := h.PodStore.Update(&pod)
+		if err != nil {
+			t.Errorf("failed to update pod in store after schedule")
+		}
+	}
+	return extenderPredicateResult
 }
 
 // TerminatePod terminates an existing pod
@@ -191,7 +200,7 @@ func (h *Harness) TerminatePod(pod v1.Pod) error {
 
 // AssertSuccessfulSchedule tries to schedule the provided pods and fails the test if not successful
 func (h *Harness) AssertSuccessfulSchedule(t *testing.T, pod v1.Pod, nodeNames []string, errorDetails string) {
-	result := h.Schedule(pod, nodeNames)
+	result := h.Schedule(t, pod, nodeNames)
 	if result.NodeNames == nil {
 		t.Errorf("Scheduling should succeed: %s", errorDetails)
 	}
@@ -199,7 +208,7 @@ func (h *Harness) AssertSuccessfulSchedule(t *testing.T, pod v1.Pod, nodeNames [
 
 // AssertFailedSchedule tries to schedule the provided pods and fails the test if successful
 func (h *Harness) AssertFailedSchedule(t *testing.T, pod v1.Pod, nodeNames []string, errorDetails string) {
-	result := h.Schedule(pod, nodeNames)
+	result := h.Schedule(t, pod, nodeNames)
 	if result.NodeNames != nil {
 		t.Errorf("Scheduling should not succeed: %s", errorDetails)
 	}

--- a/internal/extender/failover.go
+++ b/internal/extender/failover.go
@@ -85,14 +85,14 @@ type sparkPods struct {
 type instanceGroup string
 
 type reconciler struct {
-	podLister            *SparkPodLister
-	resourceReservations *cache.ResourceReservationCache
-	softReservations     *cache.SoftReservationStore
+	podLister                  *SparkPodLister
+	resourceReservations       *cache.ResourceReservationCache
+	softReservations           *cache.SoftReservationStore
 	resourceReservationManager *ResourceReservationManager
-	demands              *cache.SafeDemandCache
-	availableResources   map[instanceGroup]resources.NodeGroupResources
-	orderedNodes         map[instanceGroup][]*v1.Node
-	instanceGroupLabel   string
+	demands                    *cache.SafeDemandCache
+	availableResources         map[instanceGroup]resources.NodeGroupResources
+	orderedNodes               map[instanceGroup][]*v1.Node
+	instanceGroupLabel         string
 }
 
 func (r *reconciler) syncResourceReservations(ctx context.Context, sp *sparkPods) []*v1.Pod {

--- a/internal/extender/failover.go
+++ b/internal/extender/failover.go
@@ -24,6 +24,7 @@ import (
 	"github.com/palantir/k8s-spark-scheduler/internal"
 	"github.com/palantir/k8s-spark-scheduler/internal/cache"
 	"github.com/palantir/k8s-spark-scheduler/internal/common"
+	"github.com/palantir/k8s-spark-scheduler/internal/common/utils"
 	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	v1 "k8s.io/api/core/v1"
@@ -53,7 +54,7 @@ func (s *SparkSchedulerExtender) syncResourceReservationsAndDemands(ctx context.
 	staleSparkPods := unreservedSparkPodsBySparkID(ctx, rrs, s.softReservationStore, pods)
 	svc1log.FromContext(ctx).Info("starting reconciliation", svc1log.SafeParam("appCount", len(staleSparkPods)))
 
-	r := &reconciler{s.podLister, s.resourceReservations, s.softReservationStore, s.resourceReservationManager, s.demands, availableResources, orderedNodes, s.instanceGroupLabel}
+	r := &reconciler{s.podLister, s.resourceReservations, s.softReservationStore, s.demands, availableResources, orderedNodes, s.instanceGroupLabel}
 
 	extraExecutorsWithNoRRs := make(map[string][]*v1.Pod)
 	for _, sp := range staleSparkPods {
@@ -85,14 +86,13 @@ type sparkPods struct {
 type instanceGroup string
 
 type reconciler struct {
-	podLister                  *SparkPodLister
-	resourceReservations       *cache.ResourceReservationCache
-	softReservations           *cache.SoftReservationStore
-	resourceReservationManager *ResourceReservationManager
-	demands                    *cache.SafeDemandCache
-	availableResources         map[instanceGroup]resources.NodeGroupResources
-	orderedNodes               map[instanceGroup][]*v1.Node
-	instanceGroupLabel         string
+	podLister            *SparkPodLister
+	resourceReservations *cache.ResourceReservationCache
+	softReservations     *cache.SoftReservationStore
+	demands              *cache.SafeDemandCache
+	availableResources   map[instanceGroup]resources.NodeGroupResources
+	orderedNodes         map[instanceGroup][]*v1.Node
+	instanceGroupLabel   string
 }
 
 func (r *reconciler) syncResourceReservations(ctx context.Context, sp *sparkPods) []*v1.Pod {
@@ -325,7 +325,7 @@ func (r *reconciler) patchResourceReservation(execs []*v1.Pod, rr *v1beta1.Resou
 				break
 			}
 			pod, err := r.podLister.Pods(e.Namespace).Get(currentPodName)
-			if errors.IsNotFound(err) || (err == nil && r.resourceReservationManager.IsPodTerminated(pod)) {
+			if errors.IsNotFound(err) || (err == nil && utils.IsPodTerminated(pod)) {
 				rr.Status.Pods[name] = e.Name
 				break
 			}
@@ -367,14 +367,14 @@ func (r *reconciler) constructResourceReservation(
 		executorNodes = append(executorNodes, e.Spec.NodeName)
 	}
 	executorNodes = append(executorNodes, reservedNodeNames...)
-	rr := r.resourceReservationManager.NewResourceReservation(
+	rr := newResourceReservation(
 		driver.Spec.NodeName,
 		executorNodes,
 		driver,
 		applicationResources.driverResources,
 		applicationResources.executorResources)
 	for i, e := range executors {
-		rr.Status.Pods[r.resourceReservationManager.ExecutorReservationName(i)] = e.Name
+		rr.Status.Pods[executorReservationName(i)] = e.Name
 	}
 	return rr, reservedResources, nil
 }

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -369,7 +369,7 @@ func (s *SparkSchedulerExtender) selectExecutorNode(ctx context.Context, executo
 		return "", failureInternal, werror.WrapWithContextParams(ctx, err, "error when checking for free executor spots")
 	}
 	if freeExecutorSpots > 0 {
-		isExtraExecutor := len(unboundReservationNodes) > 0			// Dynamic allocation executor since there were no free unbound reservations
+		isExtraExecutor := len(unboundReservationNodes) > 0 // Dynamic allocation executor since there were no free unbound reservations
 		nodeName, outcome, err := s.rescheduleExecutor(ctx, executor, nodeNames, isExtraExecutor)
 		if err != nil {
 			return "", outcome, werror.WrapWithContextParams(ctx, err, "failed to reschedule executor")

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -16,7 +16,6 @@ package extender
 
 import (
 	"context"
-	"github.com/palantir/k8s-spark-scheduler/internal/common/utils"
 	"time"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
@@ -24,11 +23,12 @@ import (
 	"github.com/palantir/k8s-spark-scheduler/internal"
 	"github.com/palantir/k8s-spark-scheduler/internal/cache"
 	"github.com/palantir/k8s-spark-scheduler/internal/common"
+	"github.com/palantir/k8s-spark-scheduler/internal/common/utils"
 	"github.com/palantir/k8s-spark-scheduler/internal/events"
 	"github.com/palantir/k8s-spark-scheduler/internal/metrics"
-	"github.com/palantir/witchcraft-go-error"
+	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
@@ -57,12 +57,12 @@ const (
 // a spark driver and all of the executors can be scheduled together given current
 // resources available across the nodes
 type SparkSchedulerExtender struct {
-	nodeLister           corelisters.NodeLister
-	podLister            *SparkPodLister
-	resourceReservations *cache.ResourceReservationCache
-	softReservationStore *cache.SoftReservationStore
+	nodeLister                 corelisters.NodeLister
+	podLister                  *SparkPodLister
+	resourceReservations       *cache.ResourceReservationCache
+	softReservationStore       *cache.SoftReservationStore
 	resourceReservationManager *ResourceReservationManager
-	coreClient           corev1.CoreV1Interface
+	coreClient                 corev1.CoreV1Interface
 
 	demands             *cache.SafeDemandCache
 	apiExtensionsClient apiextensionsclientset.Interface
@@ -100,7 +100,7 @@ func NewExtender(
 		podLister:                            podLister,
 		resourceReservations:                 resourceReservations,
 		softReservationStore:                 softReservationStore,
-		resourceReservationManager:			  resourceReservationManager,
+		resourceReservationManager:           resourceReservationManager,
 		coreClient:                           coreClient,
 		demands:                              demands,
 		apiExtensionsClient:                  apiExtensionsClient,

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -59,6 +59,8 @@ const (
 type SparkSchedulerExtender struct {
 	nodeLister           corelisters.NodeLister
 	podLister            *SparkPodLister
+	resourceReservations *cache.ResourceReservationCache
+	softReservationStore *cache.SoftReservationStore
 	resourceReservationManager *ResourceReservationManager
 	coreClient           corev1.CoreV1Interface
 
@@ -80,6 +82,8 @@ type SparkSchedulerExtender struct {
 func NewExtender(
 	nodeLister corelisters.NodeLister,
 	podLister *SparkPodLister,
+	resourceReservations *cache.ResourceReservationCache,
+	softReservationStore *cache.SoftReservationStore,
 	resourceReservationManager *ResourceReservationManager,
 	coreClient corev1.CoreV1Interface,
 	demands *cache.SafeDemandCache,
@@ -94,6 +98,8 @@ func NewExtender(
 	return &SparkSchedulerExtender{
 		nodeLister:                           nodeLister,
 		podLister:                            podLister,
+		resourceReservations:                 resourceReservations,
+		softReservationStore:                 softReservationStore,
 		resourceReservationManager:			  resourceReservationManager,
 		coreClient:                           coreClient,
 		demands:                              demands,

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -382,7 +382,7 @@ func (s *SparkSchedulerExtender) selectExecutorNode(ctx context.Context, executo
 		return nodeName, successRescheduled, nil
 	}
 
-	return "", failureFit, werror.ErrorWithContextParams(ctx, "application has no free executor spots to schedule this one")
+	return "", failureUnbound, werror.ErrorWithContextParams(ctx, "application has no free executor spots to schedule this one")
 }
 
 // getReservationNodeFromNodeList filters the list of reservationNodes to return a single one that also appears in nodeNames, or false.

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -372,7 +372,7 @@ func (s *SparkSchedulerExtender) selectExecutorNode(ctx context.Context, executo
 		return "", failureInternal, werror.WrapWithContextParams(ctx, err, "error when checking for free executor spots")
 	}
 	if freeExecutorSpots > 0 {
-		isExtraExecutor := len(unboundReservationNodes) > 0 // Dynamic allocation executor since there were no free unbound reservations
+		isExtraExecutor := !foundUnbound // Dynamic allocation executor since there were no free unbound reservations
 		nodeName, outcome, err := s.rescheduleExecutor(ctx, executor, nodeNames, isExtraExecutor)
 		if err != nil {
 			return "", outcome, werror.WrapWithContextParams(ctx, err, "failed to reschedule executor")

--- a/internal/extender/resource_test.go
+++ b/internal/extender/resource_test.go
@@ -79,8 +79,8 @@ func TestDynamicAllocationScheduling(t *testing.T) {
 		name:           "creates a reservation when under min executor count",
 		podsToSchedule: extendertest.DynamicAllocationSparkPods("dynamic-allocation-app", 1, 3),
 		scenario: func(harness *extendertest.Harness, podsToSchedule []v1.Pod, nodeNames []string) {
-			harness.Schedule(podsToSchedule[0], nodeNames)
-			harness.Schedule(podsToSchedule[1], nodeNames)
+			harness.Schedule(t, podsToSchedule[0], nodeNames)
+			harness.Schedule(t, podsToSchedule[1], nodeNames)
 		},
 		expectedReservations:     []string{executor(0)},
 		expectedSoftReservations: []string{},
@@ -88,9 +88,9 @@ func TestDynamicAllocationScheduling(t *testing.T) {
 		name:           "creates a soft reservation for an executor over min executor count",
 		podsToSchedule: extendertest.DynamicAllocationSparkPods("dynamic-allocation-app", 1, 3),
 		scenario: func(harness *extendertest.Harness, podsToSchedule []v1.Pod, nodeNames []string) {
-			harness.Schedule(podsToSchedule[0], nodeNames)
-			harness.Schedule(podsToSchedule[1], nodeNames)
-			harness.Schedule(podsToSchedule[2], nodeNames)
+			harness.Schedule(t, podsToSchedule[0], nodeNames)
+			harness.Schedule(t, podsToSchedule[1], nodeNames)
+			harness.Schedule(t, podsToSchedule[2], nodeNames)
 		},
 		expectedReservations:     []string{executor(0)},
 		expectedSoftReservations: []string{executor(1)},
@@ -99,9 +99,9 @@ func TestDynamicAllocationScheduling(t *testing.T) {
 		podsToSchedule: extendertest.DynamicAllocationSparkPods("dynamic-allocation-app", 1, 3),
 		scenario: func(harness *extendertest.Harness, podsToSchedule []v1.Pod, nodeNames []string) {
 			for _, pod := range podsToSchedule {
-				harness.Schedule(pod, nodeNames)
+				harness.Schedule(t, pod, nodeNames)
 			}
-			harness.Schedule(podsToSchedule[3], nodeNames) // should not have any reservation
+			harness.Schedule(t, podsToSchedule[3], nodeNames) // should not have any reservation
 		},
 		expectedReservations:     []string{executor(0)},
 		expectedSoftReservations: []string{executor(1), executor(2)},
@@ -109,14 +109,14 @@ func TestDynamicAllocationScheduling(t *testing.T) {
 		name:           "replaces a dead executor's resource reservation before adding a new soft reservation",
 		podsToSchedule: extendertest.DynamicAllocationSparkPods("dynamic-allocation-app", 1, 3),
 		scenario: func(harness *extendertest.Harness, podsToSchedule []v1.Pod, nodeNames []string) {
-			harness.Schedule(podsToSchedule[0], nodeNames) // driver
-			harness.Schedule(podsToSchedule[1], nodeNames) // executor-0 with a resource reservation
-			harness.Schedule(podsToSchedule[2], nodeNames) // executor-1 with a soft reservation
+			harness.Schedule(t, podsToSchedule[0], nodeNames) // driver
+			harness.Schedule(t, podsToSchedule[1], nodeNames) // executor-0 with a resource reservation
+			harness.Schedule(t, podsToSchedule[2], nodeNames) // executor-1 with a soft reservation
 			// kill executor-0
 			if err := harness.TerminatePod(podsToSchedule[1]); err != nil {
 				t.Fatal("Could not terminate pod in test extender")
 			}
-			harness.Schedule(podsToSchedule[3], nodeNames) // executor-2 should have a resource reservation
+			harness.Schedule(t, podsToSchedule[3], nodeNames) // executor-2 should have a resource reservation
 		},
 		expectedReservations:     []string{executor(2)},
 		expectedSoftReservations: []string{executor(1)},

--- a/internal/extender/resourcereservations.go
+++ b/internal/extender/resourcereservations.go
@@ -241,7 +241,7 @@ func (rrm *ResourceReservationManager) getUnboundReservations(ctx context.Contex
 	for reservationName, reservation := range resourceReservation.Spec.Reservations {
 		podIdentifier, ok := resourceReservation.Status.Pods[reservationName]
 		pod, isActivePod := activePodNames[podIdentifier]
-		if !ok || !isActivePod || pod.Spec.NodeName != reservation.Node {
+		if !ok || !isActivePod || (pod.Spec.NodeName != "" && pod.Spec.NodeName != reservation.Node) {
 			unboundReservationsToNodes[reservationName] = reservation.Node
 		}
 	}

--- a/internal/extender/resourcereservations.go
+++ b/internal/extender/resourcereservations.go
@@ -15,18 +15,224 @@
 package extender
 
 import (
+	"context"
 	"fmt"
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/logging"
+	"github.com/palantir/k8s-spark-scheduler/internal/cache"
+	"github.com/palantir/k8s-spark-scheduler/internal/common/utils"
+	"github.com/palantir/witchcraft-go-error"
+	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+	"k8s.io/apimachinery/pkg/labels"
+	"sort"
+	"sync"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta1"
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"github.com/palantir/k8s-spark-scheduler/internal/common"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var podGroupVersionKind = v1.SchemeGroupVersion.WithKind("Pod")
 
-func newResourceReservation(driverNode string, executorNodes []string, driver *v1.Pod, driverResources, executorResources *resources.Resources) *v1beta1.ResourceReservation {
+type ResourceReservationManager struct {
+	resourceReservations *cache.ResourceReservationCache
+	softReservationStore *cache.SoftReservationStore
+	podLister            *SparkPodLister
+	mutex 		 		 sync.RWMutex
+}
+
+func NewResourceReservationManager(
+	resourceReservations *cache.ResourceReservationCache,
+	softReservationStore *cache.SoftReservationStore,
+	podLister            *SparkPodLister) *ResourceReservationManager  {
+	return &ResourceReservationManager{
+		resourceReservations: resourceReservations,
+		softReservationStore: softReservationStore,
+		podLister: podLister,
+	}
+}
+
+func (rrm *ResourceReservationManager) GetResourceReservation(pod *v1.Pod) (*v1beta1.ResourceReservation, bool) {
+	return rrm.resourceReservations.Get(pod.Namespace, pod.Labels[common.SparkAppIDLabel])
+}
+
+// CreateReservations creates the necessary reservations for an application whether those are resource reservation objects or
+// in-memory soft reservations for extra executors.
+func (rrm *ResourceReservationManager) CreateReservations(
+	ctx context.Context,
+	driver *v1.Pod,
+	applicationResources *sparkApplicationResources,
+	driverNode string,
+	executorNodes []string) (*v1beta1.ResourceReservation, error) {
+	rr, ok := rrm.GetResourceReservation(driver); if !ok {
+		svc1log.FromContext(ctx).Debug("creating executor resource reservations", svc1log.SafeParams(logging.RRSafeParam(rr)))
+		rr = rrm.newResourceReservation(driverNode, executorNodes, driver, applicationResources.driverResources, applicationResources.executorResources)
+		err := rrm.resourceReservations.Create(rr)
+		if err != nil {
+			return nil, werror.WrapWithContextParams(ctx, err, "failed to create resource reservation", werror.SafeParam("reservationName", rr.Name))
+		}
+	}
+
+	if applicationResources.maxExecutorCount > applicationResources.minExecutorCount {
+		// only create soft reservations for applications which can request extra executors
+		svc1log.FromContext(ctx).Debug("creating soft reservations for application", svc1log.SafeParam("appID", driver.Labels[common.SparkAppIDLabel]))
+		rrm.softReservationStore.CreateSoftReservationIfNotExists(driver.Labels[common.SparkAppIDLabel])
+	}
+
+	return rr, nil
+}
+
+// FindAlreadyBoundReservationNode returns a node name that was previously allocated to this executor, if any.
+// Binding reservations have to be idempotent. Binding the pod to the node on kube-scheduler might fail, so we want to get the same executor pod on a retry.
+func (rrm *ResourceReservationManager) FindAlreadyBoundReservationNode(ctx context.Context, executor *v1.Pod) (string, error) {
+	resourceReservation, ok := rrm.GetResourceReservation(executor)
+	if !ok {
+		return "", werror.ErrorWithContextParams(ctx, "failed to get resource reservations")
+	}
+	for name := range resourceReservation.Spec.Reservations {
+		if resourceReservation.Status.Pods[name] == executor.Name {
+			return resourceReservation.Spec.Reservations[name].Node, nil
+		}
+	}
+	// TODO(rkaram): Check soft reservations as well
+	return "", nil
+}
+
+// FindUnboundReservationNodes returns a slice of node names that have unbound reservations for this Spark application.
+// This includes both reservations we have not yet scheduled any executors on as well as reservations that have executors that are now dead.
+// Spark will recreate lost executors, so the replacement executors should be placed on the reserved spaces of dead executors.
+func (rrm *ResourceReservationManager) FindUnboundReservationNodes(ctx context.Context, executor *v1.Pod) ([]string, error) {
+	unboundReservationsToNodes, err := rrm.getUnboundReservations(ctx, executor)
+	if err != nil {
+		return []string{}, err
+	}
+	unboundReservationNodes := utils.NewStringSet(len(unboundReservationsToNodes))
+	for _, node := range unboundReservationsToNodes {
+		unboundReservationNodes.Add(node)
+	}
+	return unboundReservationNodes.ToSlice(), nil
+}
+
+func (rrm *ResourceReservationManager) GetFreeExecutorSpots(appId string) int {
+	// count unbound reservations + free soft reservations
+}
+
+func (rrm *ResourceReservationManager) ReserveForExecutor(ctx context.Context, executor *v1.Pod, node string) error {
+	rrm.mutex.Lock()
+	defer rrm.mutex.Unlock()
+
+	// TODO: make sure executor doesn't already have a reservation, if it does, it must be freed (we don't seem to handle this currently)
+
+	unboundReservationsToNodes, err := rrm.getUnboundReservations(ctx, executor)
+	if err != nil {
+		return err
+	}
+	// Sort the unbound reservations such that we favor reservations that are already tied to the requested node first
+	sortedUnboundReservations := make([]string, len(unboundReservationsToNodes))
+	for reservation := range unboundReservationsToNodes {
+		sortedUnboundReservations = append(sortedUnboundReservations, reservation)
+	}
+	sort.Slice(sortedUnboundReservations, func(i, j int) bool {
+		return unboundReservationsToNodes[sortedUnboundReservations[i]] == node
+	})
+
+	if len(sortedUnboundReservations) > 0 {
+		reservationName := sortedUnboundReservations[0]
+		return rrm.bindExecutorToResourceReservation(ctx, executor, reservationName, unboundReservationsToNodes[reservationName])
+	}
+
+	// Try to get a soft reservation if it is a dynamic allocation application
+	if rrm.getFreeExtraExecutorSpots(executor) > 0 {
+		return rrm.bindExecutorToSoftReservation(ctx, executor, node)
+	}
+
+	return werror.ErrorWithContextParams(ctx, "failed to find free reservation for executor")
+}
+
+func (rrm *ResourceReservationManager) bindExecutorToResourceReservation(ctx context.Context, executor *v1.Pod, reservationName string, node string) error {
+	resourceReservation, ok := rrm.GetResourceReservation(executor)
+	if !ok {
+		return werror.ErrorWithContextParams(ctx,"failed to get resource reservationName")
+	}
+	copyResourceReservation := resourceReservation.DeepCopy()
+	reservationObject := copyResourceReservation.Spec.Reservations[reservationName]
+	reservationObject.Node = node
+	copyResourceReservation.Spec.Reservations[reservationName] = reservationObject
+	copyResourceReservation.Status.Pods[reservationName] = executor.Name
+	err := rrm.resourceReservations.Update(copyResourceReservation)
+	if err != nil {
+		return werror.WrapWithContextParams(ctx, err, "failed to update resource reservationName")
+	}
+	return nil
+}
+
+func (rrm *ResourceReservationManager) bindExecutorToSoftReservation(ctx context.Context, executor *v1.Pod, node string) error {
+	driver, err := rrm.podLister.getDriverPod(ctx, executor)
+	if err != nil {
+		return err
+	}
+	sparkResources, err := sparkResources(ctx, driver)
+	if err != nil {
+		return err
+	}
+	softReservation := v1beta1.Reservation{
+		Node:   node,
+		CPU:    sparkResources.executorResources.CPU,
+		Memory: sparkResources.executorResources.Memory,
+	}
+	return rrm.softReservationStore.AddReservationForPod(ctx, driver.Labels[common.SparkAppIDLabel], executor.Name, softReservation)
+}
+
+func (rrm *ResourceReservationManager) getUnboundReservations(ctx context.Context, executor *v1.Pod) (map[string]string, error) {
+	resourceReservation, ok := rrm.GetResourceReservation(executor)
+	if !ok {
+		return nil, werror.ErrorWithContextParams(ctx,"failed to get resource reservation")
+	}
+	activePodNames, err := rrm.getActivePodNames(ctx, executor)
+	if err != nil {
+		return nil, err
+	}
+
+	unboundReservationsToNodes := make(map[string]string, len(resourceReservation.Spec.Reservations))
+	for reservationName, reservation := range resourceReservation.Spec.Reservations {
+		podIdentifier, ok := resourceReservation.Status.Pods[reservationName]
+		if !ok || !activePodNames[podIdentifier] {
+			unboundReservationsToNodes[reservationName] = reservation.Node
+		}
+	}
+	return unboundReservationsToNodes, nil
+}
+
+func (rrm *ResourceReservationManager) getFreeExtraExecutorSpots(executor *v1.Pod) int {
+	// count free soft reservations
+}
+
+// getActivePodNames returns a map of pod names that are still active in the passed pod's namespace
+func (rrm *ResourceReservationManager) getActivePodNames(ctx context.Context, pod *v1.Pod) (map[string]bool, error) {
+	selector := labels.Set(map[string]string{common.SparkAppIDLabel: pod.Labels[common.SparkAppIDLabel]}).AsSelector()
+	pods, err := rrm.podLister.Pods(pod.Namespace).List(selector)
+	if err != nil {
+		return nil, werror.WrapWithContextParams(ctx, err, "failed to list pods")
+	}
+	activePodNames := make(map[string]bool, len(pods))
+	for _, pod := range pods {
+		if !rrm.isPodTerminated(pod) {
+			activePodNames[pod.Name] = true
+		}
+	}
+	return activePodNames, nil
+}
+
+func (rrm *ResourceReservationManager) isPodTerminated(pod *v1.Pod) bool {
+	allTerminated := len(pod.Status.ContainerStatuses) > 0
+	for _, status := range pod.Status.ContainerStatuses {
+		allTerminated = allTerminated && status.State.Terminated != nil
+	}
+	return allTerminated
+}
+
+func (rrm *ResourceReservationManager) newResourceReservation(driverNode string, executorNodes []string, driver *v1.Pod, driverResources, executorResources *resources.Resources) *v1beta1.ResourceReservation {
 	reservations := make(map[string]v1beta1.Reservation, len(executorNodes)+1)
 	reservations["driver"] = v1beta1.Reservation{
 		Node:   driverNode,
@@ -34,7 +240,7 @@ func newResourceReservation(driverNode string, executorNodes []string, driver *v
 		Memory: driverResources.Memory,
 	}
 	for idx, nodeName := range executorNodes {
-		reservations[executorReservationName(idx)] = v1beta1.Reservation{
+		reservations[rrm.executorReservationName(idx)] = v1beta1.Reservation{
 			Node:   nodeName,
 			CPU:    executorResources.CPU,
 			Memory: executorResources.Memory,
@@ -58,6 +264,6 @@ func newResourceReservation(driverNode string, executorNodes []string, driver *v
 	}
 }
 
-func executorReservationName(i int) string {
+func (rrm *ResourceReservationManager) executorReservationName(i int) string {
 	return fmt.Sprintf("executor-%d", i+1)
 }

--- a/internal/extender/resourcereservations.go
+++ b/internal/extender/resourcereservations.go
@@ -149,7 +149,7 @@ func (rrm *ResourceReservationManager) ReserveForExecutorOnUnboundReservation(ct
 	}
 	for reservationName, reservationNode := range unboundReservationsToNodes {
 		if reservationNode == node {
-			return rrm.bindExecutorToResourceReservation(ctx, executor, reservationName, reservationNode)
+			return rrm.bindExecutorToResourceReservation(ctx, executor, reservationName, node)
 		}
 	}
 
@@ -168,8 +168,7 @@ func (rrm *ResourceReservationManager) ReserveForExecutorOnRescheduledNode(ctx c
 	}
 
 	if len(unboundReservationsToNodes) > 0 {
-		reservationName, _ := getAKeyFromMap(unboundReservationsToNodes)
-		return rrm.bindExecutorToResourceReservation(ctx, executor, reservationName, unboundReservationsToNodes[reservationName])
+		return rrm.bindExecutorToResourceReservation(ctx, executor, getAKeyFromMap(unboundReservationsToNodes), node)
 	}
 
 	// Try to get a soft reservation if it is a dynamic allocation application
@@ -322,9 +321,9 @@ func executorReservationName(i int) string {
 	return fmt.Sprintf("executor-%d", i+1)
 }
 
-func getAKeyFromMap(input map[string]string) (string, bool) {
+func getAKeyFromMap(input map[string]string) string {
 	for key := range input {
-		return key, true
+		return key
 	}
-	return "", false
+	return ""
 }

--- a/internal/extender/resourcereservations.go
+++ b/internal/extender/resourcereservations.go
@@ -71,8 +71,8 @@ func (rrm *ResourceReservationManager) CreateReservations(
 	executorNodes []string) (*v1beta1.ResourceReservation, error) {
 	rr, ok := rrm.GetResourceReservation(driver)
 	if !ok {
-		svc1log.FromContext(ctx).Debug("creating executor resource reservations", svc1log.SafeParams(logging.RRSafeParam(rr)))
 		rr = rrm.NewResourceReservation(driverNode, executorNodes, driver, applicationResources.driverResources, applicationResources.executorResources)
+		svc1log.FromContext(ctx).Debug("creating executor resource reservations", svc1log.SafeParams(logging.RRSafeParam(rr)))
 		err := rrm.resourceReservations.Create(rr)
 		if err != nil {
 			return nil, werror.WrapWithContextParams(ctx, err, "failed to create resource reservation", werror.SafeParam("reservationName", rr.Name))


### PR DESCRIPTION
This PR refactors the way we get and create both resource reservations as well as soft reservations. The aim of this is two fold:
1. Simplify the logic in the scheduling code paths by abstracting away common functionality such as checking for unbound reservations, checking for free extra executor space, patching the reservation object, etc...
2. Introduce a common place through which all reads and writes of reservations go through which will enable us to introduce new functionality in the future

This PR does not currently include refactoring the failover code, but we should handle this in a separate PR.
