### PR TITLE
Fixes the reporting of the reschedule outcome

### DIFF
--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -388,7 +388,7 @@ func (s *SparkSchedulerExtender) selectExecutorNode(ctx context.Context, executo
 		if err != nil {
 			return "", failureInternal, werror.WrapWithContextParams(ctx, err, "failed to reserve node for rescheduled executor")
 		}
-		return nodeName, successRescheduled, nil
+		return nodeName, outcome, nil
 	}
 
 	return "", failureUnbound, werror.ErrorWithContextParams(ctx, "application has no free executor spots to schedule this one")


### PR DESCRIPTION
https://github.com/palantir/k8s-spark-scheduler/pull/116 introduced a small regression in reporting the reschedule outcome in the case of dynamic allocation executors whereby we were reporting `successRescheduled` instead of the more specific `successScheduledExtraExecutor`