### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To set up the scheduler extender as a new scheduler named `spark-scheduler`, run
 ```sh
 kubectl apply -f examples/extender.yml
 ```
-This will create a new service account, a cluster binding for permissions, a config map and a deployment, all under namespace `kube-system`. It is worth noting that this example sets up the new scheduler with a super user.
+This will create a new service account, a cluster binding for permissions, a config map and a deployment, all under namespace `spark`. It is worth noting that this example sets up the new scheduler with a super user.
 
 Refer to [Spark's website](https://spark.apache.org/docs/2.3.0/running-on-kubernetes.html) for documentation on running Spark with Kubernetes. To schedule a spark application using spark-scheduler, you must apply the following metadata to driver and executor pods.
 ### driver:


### PR DESCRIPTION
kubectl apply -f examples/extender.yml creates a new serviceAccount, clusterBinding, configMap and Deployment all under the namespace "spark" and not the kube-system namespace. 

Updating the Readme.md and opening a PR for the change.