### PR TITLE
Detailed after demand waste metric with failure outcomes

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -176,6 +176,8 @@ func initServer(ctx context.Context, info witchcraft.InitInfo) (func(), error) {
 
 	binpacker := extender.SelectBinpacker(install.BinpackAlgo)
 
+	wasteMetricsReporter := metrics.NewWasteMetricsReporter(ctx, instanceGroupLabel)
+
 	sparkSchedulerExtender := extender.NewExtender(
 		nodeLister,
 		sparkPodLister,
@@ -193,6 +195,7 @@ func initServer(ctx context.Context, info witchcraft.InitInfo) (func(), error) {
 			install.DriverPrioritizedNodeLabel,
 			install.ExecutorPrioritizedNodeLabel,
 		),
+		wasteMetricsReporter,
 	)
 
 	resourceReporter := metrics.NewResourceReporter(
@@ -224,7 +227,7 @@ func initServer(ctx context.Context, info witchcraft.InitInfo) (func(), error) {
 	resourceReservationCache.Run(ctx)
 	lazyDemandInformer.Run(ctx)
 	demandCache.Run(ctx)
-	metrics.StartSchedulingOverheadMetrics(ctx, podInformerInterface, lazyDemandInformer, instanceGroupLabel)
+	wasteMetricsReporter.StartSchedulingOverheadMetrics(podInformerInterface, lazyDemandInformer)
 	go cacheReporter.StartReporting(ctx)
 	go resourceReporter.StartReportingResourceUsage(ctx)
 	go queueReporter.StartReportingQueues(ctx)

--- a/internal/extender/extendertest/extender_test_utils.go
+++ b/internal/extender/extendertest/extender_test_utils.go
@@ -26,6 +26,7 @@ import (
 	sscache "github.com/palantir/k8s-spark-scheduler/internal/cache"
 	"github.com/palantir/k8s-spark-scheduler/internal/crd"
 	"github.com/palantir/k8s-spark-scheduler/internal/extender"
+	"github.com/palantir/k8s-spark-scheduler/internal/metrics"
 	"github.com/palantir/k8s-spark-scheduler/internal/sort"
 	"github.com/palantir/witchcraft-go-logging/wlog"
 	"github.com/palantir/witchcraft-go-logging/wlog/evtlog/evt2log"
@@ -130,6 +131,8 @@ func NewTestExtender(objects ...runtime.Object) (*Harness, error) {
 	isFIFO := true
 	binpacker := extender.SelectBinpacker("tightly-pack")
 
+	wasteMetricsReporter := metrics.NewWasteMetricsReporter(ctx, instanceGroupLabel)
+
 	sparkSchedulerExtender := extender.NewExtender(
 		nodeLister,
 		sparkPodLister,
@@ -144,6 +147,7 @@ func NewTestExtender(objects ...runtime.Object) (*Harness, error) {
 		overheadComputer,
 		instanceGroupLabel,
 		sort.NewNodeSorter(nil, nil),
+		wasteMetricsReporter,
 	)
 
 	unschedulablePodMarker := extender.NewUnschedulablePodMarker(

--- a/internal/metrics/waste.go
+++ b/internal/metrics/waste.go
@@ -40,7 +40,7 @@ var (
 		slowLogThreshold: 1 * time.Minute,
 	}
 	afterDemandFulfilled = tagInfo{
-		tag: metrics.MustNewTag(schedulingWasteTypeTagName, "after-demand-fulfilled"),
+		tag:              metrics.MustNewTag(schedulingWasteTypeTagName, "after-demand-fulfilled"),
 		slowLogThreshold: 1 * time.Minute,
 	}
 	afterDemandFulfilledNoFailures = tagInfo{
@@ -64,6 +64,9 @@ func getTagInfoForFailureAfterDemandFulfilled(outcome string) tagInfo {
 	}
 }
 
+// WasteMetricsReporter tracks and reports on scheduler latencies between demand creation and pod scheduling times in
+// granular phases so we can keep track of any delays.
+// This is a best-effort reporter in that it keeps track of state in memory.
 type WasteMetricsReporter struct {
 	ctx                      context.Context
 	info                     schedulingMetricInfoByPod
@@ -72,6 +75,7 @@ type WasteMetricsReporter struct {
 	lock                     sync.Mutex
 }
 
+// NewWasteMetricsReporter returns an instance of WasteMetricsReporter
 func NewWasteMetricsReporter(ctx context.Context, instanceGroupLabel string) *WasteMetricsReporter {
 	return &WasteMetricsReporter{
 		ctx:                      ctx,
@@ -142,8 +146,8 @@ func (r *WasteMetricsReporter) StartSchedulingOverheadMetrics(
 // MarkFailedSchedulingAttempt should be called to indicate that scheduling for the passed pod failed with that outcome.
 func (r *WasteMetricsReporter) MarkFailedSchedulingAttempt(pod *v1.Pod, outcome string) {
 	schedulingAttemptInfo := podFailedSchedulingAttempt{
-		namespace: pod.Namespace,
-		podName: pod.Name,
+		namespace:                   pod.Namespace,
+		podName:                     pod.Name,
 		failedSchedulingAttemptInfo: failedSchedulingAttemptInfo{time.Now(), outcome},
 	}
 	select {
@@ -173,8 +177,8 @@ type podKey struct {
 }
 
 type podFailedSchedulingAttempt struct {
-	namespace string
-	podName      string
+	namespace                   string
+	podName                     string
 	failedSchedulingAttemptInfo failedSchedulingAttemptInfo
 }
 


### PR DESCRIPTION
## Before
The current `after-demand-fulfilled` waste metric tracks the time it took a pod to get scheduled after a demand was fulfilled, indicating slowness somewhere in scheduler or our extender. The problem is that this dismisses other factors such as FIFO requirements where the demand might have been fulfilled, but we still can't schedule the pod due to an earlier one that was still not scheduled.

## After
We differentiate between waste after demand fulfilled because of scheduler slowness and other scheduling failure outcomes.

## Notes
This uses a best effort in-memory tracker of last failure outcome since we don't commit the result anywhere and it would not currently be worth publishing object updates for this specific metric.