### PR TITLE
Node Overhead Calculation Refactor

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -167,11 +167,9 @@ func initServer(ctx context.Context, info witchcraft.InitInfo) (func(), error) {
 
 	overheadComputer := extender.NewOverheadComputer(
 		ctx,
-		podLister,
-		resourceReservationCache,
-		softReservationStore,
+		podInformerInterface,
+		resourceReservationManager,
 		nodeLister,
-		instanceGroupLabel,
 	)
 
 	binpacker := extender.SelectBinpacker(install.BinpackAlgo)
@@ -233,7 +231,6 @@ func initServer(ctx context.Context, info witchcraft.InitInfo) (func(), error) {
 	go resourceReporter.StartReportingResourceUsage(ctx)
 	go queueReporter.StartReportingQueues(ctx)
 	go softReservationReporter.StartReporting(ctx)
-	go overheadComputer.Start(ctx)
 	go unschedulablePodMarker.Start(ctx)
 
 	if err := registerExtenderEndpoints(info.Router, sparkSchedulerExtender); err != nil {

--- a/internal/extender/extendertest/extender_test_utils.go
+++ b/internal/extender/extendertest/extender_test_utils.go
@@ -121,11 +121,9 @@ func NewTestExtender(objects ...runtime.Object) (*Harness, error) {
 
 	overheadComputer := extender.NewOverheadComputer(
 		ctx,
-		podLister,
-		resourceReservationCache,
-		softReservationStore,
+		podInformerInterface,
+		resourceReservationManager,
 		nodeLister,
-		instanceGroupLabel,
 	)
 
 	isFIFO := true

--- a/internal/extender/failover.go
+++ b/internal/extender/failover.go
@@ -68,9 +68,6 @@ func (s *SparkSchedulerExtender) syncResourceReservationsAndDemands(ctx context.
 	if err != nil {
 		return nil
 	}
-
-	// recompute overhead to account for newly created resource reservations
-	s.overheadComputer.compute(ctx)
 	return nil
 }
 

--- a/internal/extender/overhead.go
+++ b/internal/extender/overhead.go
@@ -16,20 +16,18 @@ package extender
 
 import (
 	"context"
-	"sort"
 	"sync"
-	"time"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
-	"github.com/palantir/k8s-spark-scheduler/internal/cache"
 	"github.com/palantir/k8s-spark-scheduler/internal/common"
-	werror "github.com/palantir/witchcraft-go-error"
+	"github.com/palantir/k8s-spark-scheduler/internal/common/utils"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
-	"github.com/palantir/witchcraft-go-logging/wlog/wapp"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
+	clientcache "k8s.io/client-go/tools/cache"
 )
 
 var (
@@ -39,151 +37,165 @@ var (
 
 // OverheadComputer computes non spark scheduler managed pods total resources periodically
 type OverheadComputer struct {
-	podLister                    corelisters.PodLister
-	resourceReservations         *cache.ResourceReservationCache
-	softReservationStore         *cache.SoftReservationStore
-	nodeLister                   corelisters.NodeLister
-	latestOverhead               Overhead
-	latestNonSchedulableOverhead Overhead
-	overheadLock                 *sync.RWMutex
-	instanceGroupLabel           string
+	podInformer                coreinformers.PodInformer
+	resourceReservationManager *ResourceReservationManager
+	resourceRequests           ClusterRequests
+	nodeLister                 corelisters.NodeLister
+	overheadLock               *sync.RWMutex
+	ctx                        context.Context
 }
 
-// Overhead represents the overall overhead in the cluster, indexed by instance groups
-type Overhead map[string]*InstanceGroupOverhead
+// ClusterRequests represents the pod requests in the cluster, indexed by node name
+type ClusterRequests map[string]NodeRequests
 
-// InstanceGroupOverhead keeps overhead for a group of nodes, and the median overhead
-type InstanceGroupOverhead struct {
-	overhead       resources.NodeGroupResources
-	medianOverhead *resources.Resources
+// NodeRequests represents the currently present pod requests on this node, indexed by pod uid
+type NodeRequests map[types.UID]PodRequestInfo
+
+// PodRequestInfo holds information about a pod and its requested resources
+type PodRequestInfo struct {
+	podName      string
+	podNamespace string
+	requests     *resources.Resources
 }
 
 // NewOverheadComputer creates a new OverheadComputer instance
 func NewOverheadComputer(
 	ctx context.Context,
-	podLister corelisters.PodLister,
-	resourceReservations *cache.ResourceReservationCache,
-	softReservationStore *cache.SoftReservationStore,
-	nodeLister corelisters.NodeLister,
-	instanceGroupLabel string) *OverheadComputer {
+	podInformer coreinformers.PodInformer,
+	resourceReservationManager *ResourceReservationManager,
+	nodeLister corelisters.NodeLister) *OverheadComputer {
 	computer := &OverheadComputer{
-		podLister:            podLister,
-		resourceReservations: resourceReservations,
-		softReservationStore: softReservationStore,
-		nodeLister:           nodeLister,
-		overheadLock:         &sync.RWMutex{},
-		instanceGroupLabel:   instanceGroupLabel,
+		podInformer:                podInformer,
+		resourceReservationManager: resourceReservationManager,
+		nodeLister:                 nodeLister,
+		overheadLock:               &sync.RWMutex{},
+		ctx:                        ctx,
 	}
-	computer.compute(ctx)
+
+	podInformer.Informer().AddEventHandler(
+		clientcache.FilteringResourceEventHandler{
+			FilterFunc: computer.podHasNodeName,
+			Handler: clientcache.ResourceEventHandlerFuncs{
+				AddFunc:    computer.addPodRequests,
+				DeleteFunc: computer.deletePodRequests,
+			},
+		})
 	return computer
 }
 
-// Start starts periodic scanning for overhead
-func (o *OverheadComputer) Start(ctx context.Context) {
-	_ = wapp.RunWithFatalLogging(ctx, o.doStart)
+func (o *OverheadComputer) getOrCreateNodeRequests(nodeName string) NodeRequests {
+	nodeRequests, ok := o.resourceRequests[nodeName]
+	if !ok {
+		nodeRequests = NodeRequests{}
+		o.resourceRequests[nodeName] = nodeRequests
+	}
+	return nodeRequests
 }
 
-// GetOverhead fills overhead information for given nodes, and falls back to the median overhead
-// of the instance group if the node is not found
+// GetOverhead fills overhead information for given nodes.
 func (o OverheadComputer) GetOverhead(ctx context.Context, nodes []*v1.Node) resources.NodeGroupResources {
-	o.overheadLock.RLock()
-	defer o.overheadLock.RUnlock()
-	return o.getOverheadByNode(ctx, o.latestOverhead, nodes)
+	ov, _ := o.getOverheadByNode(ctx, nodes)
+	return ov
 }
 
-// GetNonSchedulableOverhead fills non-schedulable overhead information for given nodes, and falls back to the median overhead
-// of the instance group if the node is not found.
+// GetNonSchedulableOverhead fills non-schedulable overhead information for given nodes.
 // Non-schedulable overhead is overhead by pods that are running, but do not have 'spark-scheduler' as their scheduler name.
 func (o OverheadComputer) GetNonSchedulableOverhead(ctx context.Context, nodes []*v1.Node) resources.NodeGroupResources {
+	_, nso := o.getOverheadByNode(ctx, nodes)
+	return nso
+}
+
+// getOverheadByNode computes and returns the overhead per node name.
+// This returns (overhead per node, nonSchedulableOverhead per node).
+func (o OverheadComputer) getOverheadByNode(ctx context.Context, nodes []*v1.Node) (resources.NodeGroupResources, resources.NodeGroupResources) {
+	overhead := resources.NodeGroupResources{}
+	nonSchedulableOverhead := resources.NodeGroupResources{}
+
+	for _, n := range nodes {
+		ov, nso := o.computeNodeOverhead(ctx, n.Name)
+		overhead[n.Name] = ov
+		nonSchedulableOverhead[n.Name] = nso
+	}
+	svc1log.FromContext(ctx).Debug("using overhead for nodes", svc1log.SafeParam("overhead", overhead), svc1log.SafeParam("nonSchedulableOverhead", nonSchedulableOverhead))
+	return overhead, nonSchedulableOverhead
+}
+
+// computeNodeOverhead adds the requests of pods that don't have reservations and are counted as overhead.
+// This returns (overhead, nonSchedulableOverhead).
+func (o *OverheadComputer) computeNodeOverhead(ctx context.Context, nodeName string) (*resources.Resources, *resources.Resources) {
 	o.overheadLock.RLock()
 	defer o.overheadLock.RUnlock()
-	return o.getOverheadByNode(ctx, o.latestNonSchedulableOverhead, nodes)
-}
-
-func (o *OverheadComputer) doStart(ctx context.Context) error {
-	t := time.NewTicker(30 * time.Second)
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-t.C:
-			o.compute(ctx)
-		}
+	nodeRequests, ok := o.resourceRequests[nodeName]
+	if !ok {
+		return resources.Zero(), resources.Zero()
 	}
-}
-
-func (o *OverheadComputer) compute(ctx context.Context) {
-	pods, err := o.podLister.List(labels.Everything())
-	if err != nil {
-		svc1log.FromContext(ctx).Error("failed to list pods", svc1log.Stacktrace(err))
-		return
-	}
-	rrs := o.resourceReservations.List()
-	podsWithRRs := make(map[string]bool, len(rrs))
-	for _, rr := range rrs {
-		for _, podName := range rr.Status.Pods {
-			podsWithRRs[podName] = true
-		}
-	}
-	rawOverhead := map[string]resources.NodeGroupResources{}
-	rawNonSchedulableOverhead := map[string]resources.NodeGroupResources{}
-	for _, p := range pods {
-		if podsWithRRs[p.Name] {
+	overhead := resources.Zero()
+	nonSchedulableOverhead := resources.Zero()
+	for _, podRequestInfo := range nodeRequests {
+		pod, err := o.podInformer.Lister().Pods(podRequestInfo.podNamespace).Get(podRequestInfo.podName)
+		if err != nil {
+			svc1log.FromContext(ctx).Warn("error when checking if pod has a reservation, node overhead calculation might be inaccurate",
+				svc1log.SafeParam("nodeName", nodeName),
+				svc1log.SafeParam("podName", podRequestInfo.podName),
+				svc1log.SafeParam("podNamespace", podRequestInfo.podNamespace))
 			continue
 		}
-		if role, ok := p.Labels[common.SparkRoleLabel]; ok {
-			if role == common.Executor && o.softReservationStore.ExecutorHasSoftReservation(ctx, p) {
-				continue
+		if !o.resourceReservationManager.PodHasReservation(ctx, pod) {
+			overhead.Add(podRequestInfo.requests)
+			if pod.Spec.SchedulerName != common.SparkSchedulerName {
+				nonSchedulableOverhead.Add(podRequestInfo.requests)
+			}
+
+			if podRequestInfo.requests.CPU.AsDec().Cmp(oneCPU.AsDec()) > 0 || podRequestInfo.requests.Memory.AsDec().Cmp(oneGiB.AsDec()) > 0 {
+				svc1log.FromContext(ctx).Debug("Container with no resource reservation has high resource requests",
+					svc1log.SafeParam("podName", pod.Name),
+					svc1log.SafeParam("nodeName", pod.Spec.NodeName),
+					svc1log.SafeParam("CPU", podRequestInfo.requests.CPU),
+					svc1log.SafeParam("Memory", podRequestInfo.requests.Memory))
 			}
 		}
-		if p.Spec.NodeName == "" || p.Status.Phase == v1.PodSucceeded || p.Status.Phase == v1.PodFailed {
-			// pending pod or pod succeeded or failed
-			continue
-		}
-
-		instanceGroup, err := o.getPodNodeInstanceGroup(p)
-		if err != nil {
-			svc1log.FromContext(ctx).Warn("could not get instance group for node where pod is running, skipping", svc1log.SafeParam("failedPod", p.Name), svc1log.Stacktrace(err))
-			continue
-		}
-
-		// found pod with no associated resource reservation, add to overhead
-		o.addPodResourcesToGroupResources(ctx, rawOverhead, p, instanceGroup)
-
-		if p.Spec.SchedulerName != common.SparkSchedulerName {
-			// add all pods that this scheduler does not deal with to the non-schedulable overhead
-			o.addPodResourcesToGroupResources(ctx, rawNonSchedulableOverhead, p, instanceGroup)
-		}
 	}
-	overhead := Overhead{}
-	for instanceGroup, nodeGroupResources := range rawOverhead {
-		medianOverhead := calculateMedianResources(nodeGroupResources)
-		svc1log.FromContext(ctx).Info("computed overhead",
-			svc1log.SafeParam("medianOverhead", medianOverhead),
-			svc1log.SafeParam("instanceGroup", instanceGroup))
+	return overhead, nonSchedulableOverhead
+}
 
-		overhead[instanceGroup] = &InstanceGroupOverhead{
-			rawOverhead[instanceGroup],
-			medianOverhead,
-		}
+func (o *OverheadComputer) podHasNodeName(obj interface{}) bool {
+	if pod, ok := utils.GetPodFromObjectOrTombstone(obj); ok {
+		return pod.Spec.NodeName != ""
 	}
+	svc1log.FromContext(o.ctx).Error("failed to parse object as pod", svc1log.UnsafeParam("obj", obj))
+	return false
+}
 
-	nonSchedulableOverhead := Overhead{}
-	for instanceGroup, nodeGroupResources := range rawNonSchedulableOverhead {
-		medianOverhead := calculateMedianResources(nodeGroupResources)
-		svc1log.FromContext(ctx).Info("computed non-schedulable overhead",
-			svc1log.SafeParam("medianOverhead", medianOverhead),
-			svc1log.SafeParam("instanceGroup", instanceGroup))
-
-		nonSchedulableOverhead[instanceGroup] = &InstanceGroupOverhead{
-			rawNonSchedulableOverhead[instanceGroup],
-			medianOverhead,
-		}
-	}
+func (o *OverheadComputer) addPodRequests(obj interface{}) {
 	o.overheadLock.Lock()
-	o.latestOverhead = overhead
-	o.latestNonSchedulableOverhead = nonSchedulableOverhead
-	o.overheadLock.Unlock()
+	defer o.overheadLock.Unlock()
+
+	pod, ok := obj.(*v1.Pod)
+	if !ok {
+		svc1log.FromContext(o.ctx).Error("failed to parse object as pod", svc1log.UnsafeParam("obj", obj))
+		return
+	}
+	nodeRequests := o.getOrCreateNodeRequests(pod.Spec.NodeName)
+	nodeRequests[pod.UID] = PodRequestInfo{pod.Name, pod.Namespace, podToResources(o.ctx, pod)}
+}
+
+func (o *OverheadComputer) deletePodRequests(obj interface{}) {
+	o.overheadLock.Lock()
+	defer o.overheadLock.Unlock()
+
+	pod, ok := utils.GetPodFromObjectOrTombstone(obj)
+	if !ok {
+		svc1log.FromContext(o.ctx).Error("failed to parse object as pod", svc1log.UnsafeParam("obj", obj))
+		return
+	}
+	nodeRequests := o.getOrCreateNodeRequests(pod.Spec.NodeName)
+	if _, ok := nodeRequests[pod.UID]; !ok {
+		return
+	}
+	delete(nodeRequests, pod.UID)
+	if len(nodeRequests) == 0 {
+		delete(o.resourceRequests, pod.Spec.NodeName)
+	}
 }
 
 func (o *OverheadComputer) addPodResourcesToGroupResources(ctx context.Context, groupResources map[string]resources.NodeGroupResources, pod *v1.Pod, instanceGroup string) {
@@ -197,22 +209,12 @@ func (o *OverheadComputer) addPodResourcesToGroupResources(ctx context.Context, 
 	currentOverhead[pod.Spec.NodeName].Add(podToResources(ctx, pod))
 }
 
-func calculateMedianResources(nodeGroupResources resources.NodeGroupResources) *resources.Resources {
-	resourcesSlice := make([]*resources.Resources, 0, len(nodeGroupResources))
-	for _, resources := range nodeGroupResources {
-		resourcesSlice = append(resourcesSlice, resources)
-	}
-	sort.Slice(resourcesSlice, func(i, j int) bool {
-		return resourcesSlice[i].GreaterThan(resourcesSlice[j])
-	})
-	return resourcesSlice[len(resourcesSlice)/2]
-}
-
 func podToResources(ctx context.Context, pod *v1.Pod) *resources.Resources {
 	res := resources.Zero()
 	for _, c := range pod.Spec.Containers {
 		resourceRequests := c.Resources.Requests
 		if resourceRequests.Cpu().AsDec().Cmp(oneCPU.AsDec()) > 0 || resourceRequests.Memory().AsDec().Cmp(oneGiB.AsDec()) > 0 {
+			// TODO(rkaram): Move this away from here
 			svc1log.FromContext(ctx).Debug("Container with no resource reservation has high resource requests",
 				svc1log.SafeParam("podName", pod.Name),
 				svc1log.SafeParam("nodeName", pod.Spec.NodeName),
@@ -221,35 +223,5 @@ func podToResources(ctx context.Context, pod *v1.Pod) *resources.Resources {
 		}
 		res.AddFromResourceList(resourceRequests)
 	}
-	return res
-}
-
-func (o *OverheadComputer) getPodNodeInstanceGroup(pod *v1.Pod) (string, error) {
-	node, err := o.nodeLister.Get(pod.Spec.NodeName)
-	if err != nil {
-		return "", werror.Wrap(err, "node does not exist in cache", werror.SafeParam("nodeName", pod.Spec.NodeName))
-	}
-	return node.Labels[o.instanceGroupLabel], nil
-}
-
-func (o OverheadComputer) getOverheadByNode(ctx context.Context, overhead Overhead, nodes []*v1.Node) resources.NodeGroupResources {
-	res := resources.NodeGroupResources{}
-	if overhead == nil {
-		return res
-	}
-	for _, n := range nodes {
-		instanceGroup := n.Labels[o.instanceGroupLabel]
-		instanceGroupOverhead := overhead[instanceGroup]
-		if instanceGroupOverhead == nil {
-			svc1log.FromContext(ctx).Warn("overhead for instance group does not exist", svc1log.SafeParam("instanceGroup", instanceGroup))
-			continue
-		}
-		if nodeOverhead, ok := instanceGroupOverhead.overhead[n.Name]; ok {
-			res[n.Name] = nodeOverhead
-		} else {
-			res[n.Name] = instanceGroupOverhead.medianOverhead
-		}
-	}
-	svc1log.FromContext(ctx).Debug("using overhead for nodes", svc1log.SafeParam("overhead", res))
 	return res
 }

--- a/internal/extender/overhead.go
+++ b/internal/extender/overhead.go
@@ -23,16 +23,10 @@ import (
 	"github.com/palantir/k8s-spark-scheduler/internal/common/utils"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	clientcache "k8s.io/client-go/tools/cache"
-)
-
-var (
-	oneCPU = resource.NewMilliQuantity(1000, resource.DecimalSI)
-	oneGiB = resource.NewQuantity(1*1024*1024*1024, resource.BinarySI)
 )
 
 // OverheadComputer computes non spark scheduler managed pods total resources periodically
@@ -142,16 +136,15 @@ func (o *OverheadComputer) computeNodeOverhead(ctx context.Context, nodeName str
 		}
 		if !o.resourceReservationManager.PodHasReservation(ctx, pod) {
 			overhead.Add(podRequestInfo.requests)
-			if pod.Spec.SchedulerName != common.SparkSchedulerName {
+			if pod.Spec.SchedulerName == common.SparkSchedulerName {
+				if _, appHasResourceReservation := o.resourceReservationManager.GetResourceReservation(pod.Labels[common.SparkAppIDLabel], pod.Namespace); appHasResourceReservation {
+					svc1log.FromContext(ctx).Warn("found spark scheduler pod with no reservation but application has a resource reservation",
+						svc1log.SafeParam("nodeName", nodeName),
+						svc1log.SafeParam("podName", podRequestInfo.podName),
+						svc1log.SafeParam("podNamespace", podRequestInfo.podNamespace))
+				}
+			} else {
 				nonSchedulableOverhead.Add(podRequestInfo.requests)
-			}
-
-			if podRequestInfo.requests.CPU.AsDec().Cmp(oneCPU.AsDec()) > 0 || podRequestInfo.requests.Memory.AsDec().Cmp(oneGiB.AsDec()) > 0 {
-				svc1log.FromContext(ctx).Debug("Container with no resource reservation has high resource requests",
-					svc1log.SafeParam("podName", pod.Name),
-					svc1log.SafeParam("nodeName", pod.Spec.NodeName),
-					svc1log.SafeParam("CPU", podRequestInfo.requests.CPU),
-					svc1log.SafeParam("Memory", podRequestInfo.requests.Memory))
 			}
 		}
 	}
@@ -198,29 +191,10 @@ func (o *OverheadComputer) deletePodRequests(obj interface{}) {
 	}
 }
 
-func (o *OverheadComputer) addPodResourcesToGroupResources(ctx context.Context, groupResources map[string]resources.NodeGroupResources, pod *v1.Pod, instanceGroup string) {
-	if _, ok := groupResources[instanceGroup]; !ok {
-		groupResources[instanceGroup] = resources.NodeGroupResources{}
-	}
-	currentOverhead := groupResources[instanceGroup]
-	if _, ok := currentOverhead[pod.Spec.NodeName]; !ok {
-		currentOverhead[pod.Spec.NodeName] = resources.Zero()
-	}
-	currentOverhead[pod.Spec.NodeName].Add(podToResources(ctx, pod))
-}
-
 func podToResources(ctx context.Context, pod *v1.Pod) *resources.Resources {
 	res := resources.Zero()
 	for _, c := range pod.Spec.Containers {
 		resourceRequests := c.Resources.Requests
-		if resourceRequests.Cpu().AsDec().Cmp(oneCPU.AsDec()) > 0 || resourceRequests.Memory().AsDec().Cmp(oneGiB.AsDec()) > 0 {
-			// TODO(rkaram): Move this away from here
-			svc1log.FromContext(ctx).Debug("Container with no resource reservation has high resource requests",
-				svc1log.SafeParam("podName", pod.Name),
-				svc1log.SafeParam("nodeName", pod.Spec.NodeName),
-				svc1log.SafeParam("CPU", resourceRequests.Cpu()),
-				svc1log.SafeParam("Memory", resourceRequests.Memory()))
-		}
 		res.AddFromResourceList(resourceRequests)
 	}
 	return res


### PR DESCRIPTION
Refactors the way we calculate node overhead to do the following:
* Make it dynamic in that it listens to pod informer events and updates requests on nodes accordingly rather than the current version which only recalculates the overhead every 30 seconds
* Only consider a pod as having returned its requested resources when it is deleted which is inline with the `kube-scheduler` calculation
* We also no longer fallback to the instance group median as we should now be able to accurately measure node overhead in realtime which makes the accurate calculation possible

The second point raises a potential issue: due to the fact that we were considering a pod as no longer requesting resources once it completes successfully or fails, we were undercounting overhead and were potentially optimistically scheduling pods on some nodes during binpacking. While more correct, the current solution means that in practice, the failure fit occurrences _might_ increase and affect scheduling times, which we should monitor.