### PR TITLE
add more explaination about memory annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ metadata:
 spec:
   schedulerName: spark-scheduler
 ```
+
+The annotated resources should be equal to what spark job really requires from k8s. Otherwise, the scheduler could try to
+deploy pods to nodes which have no enough resources. Also, the memory configuration in spark arguments (`spark.driver.memory` and
+`spark.executor.memory`) is power-of-two equivalents (In other words, `spark.executor.memory=1G` means the executor requires
+`1Gi` memory). By contrast, this scheduler treats `G` and `Gi` as different values. For another, the memory annotation
+should include the memory overheads (`spark.kubernetes.memoryOverheadFactor`, `spark.driver.memoryOverhead` 
+and `spark.executor.memoryOverhead`).
+
 ### executor:
 ```yml
 apiVersion: v1


### PR DESCRIPTION
related to https://github.com/palantir/k8s-spark-scheduler/issues/152#issuecomment-877627500

As I did not include the overhead when setting memory annotations, the scheduler tries to assign pods to nodes which have no enough (memory) resources. Also, I can observe following message from logs.

```
not enough capacity to reschedule the executor
```

