### PR TITLE
Upgrade kube-scheduler from v1.13.1 to v1.15.12

### DIFF
--- a/examples/extender.yml
+++ b/examples/extender.yml
@@ -94,7 +94,7 @@ spec:
       serviceAccountName: spark-scheduler
       containers:
       - name: kube-scheduler
-        image: gcr.io/google_containers/hyperkube:v1.13.1
+        image: gcr.io/google_containers/hyperkube:v1.15.12
         imagePullPolicy: IfNotPresent
         command:
         - sh


### PR DESCRIPTION
the `v1.13.1` was release 2 years ago. It seems to me it is a bit out-of-date. Also, the max backoff in `v1.13.1` is 1 minute (https://github.com/kubernetes/kubernetes/blob/release-1.13/pkg/scheduler/util/backoff_utils.go#L103). That can raise scheduling latency when cluster gets enough resources (add more nodes or remove completed jobs). 

`v1.15.12` is the latest version which can accept `PodPriority=false`.