### PR TITLE
Use new resource reservation crd

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -108,7 +108,7 @@ func initServer(ctx context.Context, info witchcraft.InitInfo) (func(), error) {
 	podInformer := podInformerInterface.Informer()
 	podLister := podInformerInterface.Lister()
 
-	resourceReservationInformerInterface := sparkSchedulerInformerFactory.Sparkscheduler().V1beta1().ResourceReservations()
+	resourceReservationInformerInterface := sparkSchedulerInformerFactory.Sparkscheduler().V1beta2().ResourceReservations()
 	resourceReservationInformer := resourceReservationInformerInterface.Informer()
 	resourceReservationLister := resourceReservationInformerInterface.Lister()
 
@@ -138,7 +138,7 @@ func initServer(ctx context.Context, info witchcraft.InitInfo) (func(), error) {
 	resourceReservationCache, err := cache.NewResourceReservationCache(
 		ctx,
 		resourceReservationInformerInterface,
-		sparkSchedulerClient.SparkschedulerV1beta1(),
+		sparkSchedulerClient.SparkschedulerV1beta2(),
 		install.AsyncClientConfig,
 	)
 

--- a/examples/submit-test-spark-app.sh
+++ b/examples/submit-test-spark-app.sh
@@ -29,8 +29,6 @@ metadata:
     spark-executor-count: "$EXECUTOR_COUNT"
 spec:
   schedulerName: spark-scheduler
-  nodeSelector:
-    instance-group: "main"
   containers:
   - name: nginx
     image: nginx
@@ -65,8 +63,6 @@ metadata:
     uid: $DRIVER_UID
 spec:
   schedulerName: spark-scheduler
-  nodeSelector:
-    instance-group: "main"
   containers:
   - name: nginx
     image: nginx

--- a/internal/cache/resourcereservations.go
+++ b/internal/cache/resourcereservations.go
@@ -17,9 +17,9 @@ package cache
 import (
 	"context"
 
-	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta1"
-	sparkschedulerclient "github.com/palantir/k8s-spark-scheduler-lib/pkg/client/clientset/versioned/typed/sparkscheduler/v1beta1"
-	rrinformers "github.com/palantir/k8s-spark-scheduler-lib/pkg/client/informers/externalversions/sparkscheduler/v1beta1"
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta2"
+	sparkschedulerclient "github.com/palantir/k8s-spark-scheduler-lib/pkg/client/clientset/versioned/typed/sparkscheduler/v1beta2"
+	rrinformers "github.com/palantir/k8s-spark-scheduler-lib/pkg/client/informers/externalversions/sparkscheduler/v1beta2"
 	"github.com/palantir/k8s-spark-scheduler/config"
 	"github.com/palantir/k8s-spark-scheduler/internal/cache/store"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,7 +38,7 @@ const (
 // resource reservations. Any external update and creation will be
 // ignored, but deletions will be reflected in the cache.
 type ResourceReservationCache struct {
-	client      sparkschedulerclient.SparkschedulerV1beta1Interface
+	client      sparkschedulerclient.SparkschedulerV1beta2Interface
 	cache       *cache
 	asyncClient *asyncClient
 }
@@ -47,7 +47,7 @@ type ResourceReservationCache struct {
 func NewResourceReservationCache(
 	ctx context.Context,
 	resourceReservationInformer rrinformers.ResourceReservationInformer,
-	resourceReservationKubeClient sparkschedulerclient.SparkschedulerV1beta1Interface,
+	resourceReservationKubeClient sparkschedulerclient.SparkschedulerV1beta2Interface,
 	asyncClientConfig config.AsyncClientConfig,
 ) (*ResourceReservationCache, error) {
 	rrs, err := resourceReservationInformer.Lister().List(labels.Everything())
@@ -79,12 +79,12 @@ func (rrc *ResourceReservationCache) Run(ctx context.Context) {
 }
 
 // Create enqueues a creation request and puts the object into the store
-func (rrc *ResourceReservationCache) Create(rr *v1beta1.ResourceReservation) error {
+func (rrc *ResourceReservationCache) Create(rr *v1beta2.ResourceReservation) error {
 	return rrc.cache.Create(rr)
 }
 
 // Update enqueues an update request and updates the object in store
-func (rrc *ResourceReservationCache) Update(rr *v1beta1.ResourceReservation) error {
+func (rrc *ResourceReservationCache) Update(rr *v1beta2.ResourceReservation) error {
 	return rrc.cache.Update(rr)
 }
 
@@ -94,20 +94,20 @@ func (rrc *ResourceReservationCache) Delete(namespace, name string) {
 }
 
 // Get returns the object from the store if it exists
-func (rrc *ResourceReservationCache) Get(namespace, name string) (*v1beta1.ResourceReservation, bool) {
+func (rrc *ResourceReservationCache) Get(namespace, name string) (*v1beta2.ResourceReservation, bool) {
 	obj, ok := rrc.cache.Get(namespace, name)
 	if !ok {
 		return nil, false
 	}
-	return obj.(*v1beta1.ResourceReservation), true
+	return obj.(*v1beta2.ResourceReservation), true
 }
 
 // List returns all known objects in the store
-func (rrc *ResourceReservationCache) List() []*v1beta1.ResourceReservation {
+func (rrc *ResourceReservationCache) List() []*v1beta2.ResourceReservation {
 	objects := rrc.cache.List()
-	res := make([]*v1beta1.ResourceReservation, 0, len(objects))
+	res := make([]*v1beta2.ResourceReservation, 0, len(objects))
 	for _, o := range objects {
-		res = append(res, o.(*v1beta1.ResourceReservation))
+		res = append(res, o.(*v1beta2.ResourceReservation))
 	}
 	return res
 }
@@ -118,15 +118,15 @@ func (rrc *ResourceReservationCache) InflightQueueLengths() []int {
 }
 
 type resourceReservationClient struct {
-	sparkschedulerclient.SparkschedulerV1beta1Interface
+	sparkschedulerclient.SparkschedulerV1beta2Interface
 }
 
 func (client *resourceReservationClient) Create(ctx context.Context, obj metav1.Object) (metav1.Object, error) {
-	return client.ResourceReservations(obj.GetNamespace()).Create(ctx, obj.(*v1beta1.ResourceReservation), metav1.CreateOptions{})
+	return client.ResourceReservations(obj.GetNamespace()).Create(ctx, obj.(*v1beta2.ResourceReservation), metav1.CreateOptions{})
 }
 
 func (client *resourceReservationClient) Update(ctx context.Context, obj metav1.Object) (metav1.Object, error) {
-	return client.ResourceReservations(obj.GetNamespace()).Update(ctx, obj.(*v1beta1.ResourceReservation), metav1.UpdateOptions{})
+	return client.ResourceReservations(obj.GetNamespace()).Update(ctx, obj.(*v1beta2.ResourceReservation), metav1.UpdateOptions{})
 }
 
 func (client *resourceReservationClient) Delete(ctx context.Context, namespace, name string) error {

--- a/internal/cache/softreservations.go
+++ b/internal/cache/softreservations.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta1"
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta2"
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"github.com/palantir/k8s-spark-scheduler/internal/common"
 	"github.com/palantir/k8s-spark-scheduler/internal/common/utils"
@@ -40,7 +40,7 @@ type SoftReservationStore struct {
 // min reservation count
 type SoftReservation struct {
 	// Executor pod name -> Reservation (only valid ones here)
-	Reservations map[string]v1beta1.Reservation
+	Reservations map[string]v1beta2.Reservation
 
 	// Executor pod name -> Reservation valid or not
 	// The reason for this is that we want to keep a history of previously allocated extra executors that we should not create a
@@ -97,7 +97,7 @@ func (s *SoftReservationStore) CreateSoftReservationIfNotExists(appID string) {
 	defer s.storeLock.Unlock()
 	_, ok := s.store[appID]
 	if !ok {
-		r := make(map[string]v1beta1.Reservation)
+		r := make(map[string]v1beta2.Reservation)
 		sr := &SoftReservation{
 			Reservations: r,
 			Status:       make(map[string]bool),
@@ -108,7 +108,7 @@ func (s *SoftReservationStore) CreateSoftReservationIfNotExists(appID string) {
 
 // AddReservationForPod adds a reservation for an extra executor pod, attaching the associated node and resources to it.
 // This is a noop if the reservation already exists.
-func (s *SoftReservationStore) AddReservationForPod(ctx context.Context, appID string, podName string, reservation v1beta1.Reservation) error {
+func (s *SoftReservationStore) AddReservationForPod(ctx context.Context, appID string, podName string, reservation v1beta2.Reservation) error {
 	s.storeLock.Lock()
 	defer s.storeLock.Unlock()
 	appSoftReservation, ok := s.store[appID]
@@ -133,7 +133,7 @@ func (s *SoftReservationStore) ExecutorHasSoftReservation(ctx context.Context, e
 }
 
 // GetExecutorSoftReservation returns the Reservation object associated with this executor if it exists.
-func (s *SoftReservationStore) GetExecutorSoftReservation(ctx context.Context, executor *v1.Pod) (*v1beta1.Reservation, bool) {
+func (s *SoftReservationStore) GetExecutorSoftReservation(ctx context.Context, executor *v1.Pod) (*v1beta2.Reservation, bool) {
 	s.storeLock.RLock()
 	defer s.storeLock.RUnlock()
 	appID, ok := executor.Labels[common.SparkAppIDLabel]
@@ -163,7 +163,7 @@ func (s *SoftReservationStore) UsedSoftReservationResources() resources.NodeGrou
 			if res[node] == nil {
 				res[node] = resources.Zero()
 			}
-			res[node].AddFromReservation(&reservationObject)
+			res[node].AddFromReservationV1Beta2(&reservationObject)
 		}
 	}
 	return res
@@ -218,7 +218,7 @@ func (s *SoftReservationStore) removeDriverReservation(appID string) {
 }
 
 func (s *SoftReservationStore) deepCopySoftReservation(reservation *SoftReservation) *SoftReservation {
-	reservationsCopy := make(map[string]v1beta1.Reservation, len(reservation.Reservations))
+	reservationsCopy := make(map[string]v1beta2.Reservation, len(reservation.Reservations))
 	for name, res := range reservation.Reservations {
 		reservationsCopy[name] = *res.DeepCopy()
 	}

--- a/internal/crd/utils.go
+++ b/internal/crd/utils.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta1"
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta2"
 	werror "github.com/palantir/witchcraft-go-error"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -61,7 +61,8 @@ func verifyCRD(existing, desired *v1.CustomResourceDefinition) bool {
 // EnsureResourceReservationsCRD is responsible for creating and ensuring the ResourceReservation CRD
 // is created
 func EnsureResourceReservationsCRD(ctx context.Context, clientset apiextensionsclientset.Interface, annotations map[string]string) error {
-	crd := v1beta1.ResourceReservationCustomResourceDefinition()
+	// TODO(cbattarbee) REPLACE WITH WEBHOOK
+	crd := v1beta2.ResourceReservationCustomResourceDefinitionNoWebhook()
 	if crd.Annotations == nil {
 		crd.Annotations = make(map[string]string)
 	}
@@ -98,7 +99,8 @@ func EnsureResourceReservationsCRD(ctx context.Context, clientset apiextensionsc
 		if err != nil {
 			return false, err
 		}
-		return ready && verifyCRD(existing, v1beta1.ResourceReservationCustomResourceDefinition()), nil
+		// TODO(cbattarbee) REPLACE WITH WEBHOOK
+		return ready && verifyCRD(existing, v1beta2.ResourceReservationCustomResourceDefinitionNoWebhook()), nil
 	})
 
 	if err != nil {

--- a/internal/extender/extendertest/extender_test_utils.go
+++ b/internal/extender/extendertest/extender_test_utils.go
@@ -77,7 +77,7 @@ func NewTestExtender(objects ...runtime.Object) (*Harness, error) {
 	podLister := podInformerInterface.Lister()
 
 	sparkSchedulerInformerFactory := ssinformers.NewSharedInformerFactory(fakeSchedulerClient, 0)
-	resourceReservationInformerInterface := sparkSchedulerInformerFactory.Sparkscheduler().V1beta1().ResourceReservations()
+	resourceReservationInformerInterface := sparkSchedulerInformerFactory.Sparkscheduler().V1beta2().ResourceReservations()
 	resourceReservationInformer := resourceReservationInformerInterface.Informer()
 
 	instanceGroupLabel := "resource_channel"
@@ -98,7 +98,7 @@ func NewTestExtender(objects ...runtime.Object) (*Harness, error) {
 	resourceReservationCache, err := sscache.NewResourceReservationCache(
 		ctx,
 		resourceReservationInformerInterface,
-		fakeSchedulerClient.SparkschedulerV1beta1(),
+		fakeSchedulerClient.SparkschedulerV1beta2(),
 		installConfig.AsyncClientConfig,
 	)
 	if err != nil {

--- a/internal/extender/failover.go
+++ b/internal/extender/failover.go
@@ -19,7 +19,7 @@ import (
 	"math"
 	"sort"
 
-	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta1"
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta2"
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"github.com/palantir/k8s-spark-scheduler/internal"
 	"github.com/palantir/k8s-spark-scheduler/internal/cache"
@@ -185,10 +185,12 @@ func (r *reconciler) syncSoftReservations(ctx context.Context, extraExecutorsByA
 			if i >= (applicationResources.maxExecutorCount - applicationResources.minExecutorCount) {
 				break
 			}
-			err := r.softReservations.AddReservationForPod(ctx, appID, extraExecutor.Name, v1beta1.Reservation{
-				Node:   extraExecutor.Spec.NodeName,
-				CPU:    applicationResources.executorResources.CPU,
-				Memory: applicationResources.executorResources.Memory,
+			err := r.softReservations.AddReservationForPod(ctx, appID, extraExecutor.Name, v1beta2.Reservation{
+				Node: extraExecutor.Spec.NodeName,
+				Resources: v1beta2.ResourceList{
+					string(v1beta2.ResourceCPU):    &applicationResources.executorResources.CPU,
+					string(v1beta2.ResourceMemory): &applicationResources.executorResources.Memory,
+				},
 			})
 			if err != nil {
 				svc1log.FromContext(ctx).Error("failed to add soft reservation for executor on failover. skipping...", svc1log.SafeParam("appID", appID), svc1log.Stacktrace(err))
@@ -229,7 +231,7 @@ func (r *reconciler) syncApplicationSoftReservations(ctx context.Context) error 
 
 func unreservedSparkPodsBySparkID(
 	ctx context.Context,
-	rrs []*v1beta1.ResourceReservation,
+	rrs []*v1beta2.ResourceReservation,
 	softReservationStore *cache.SoftReservationStore,
 	pods []*v1.Pod,
 ) map[string]*sparkPods {
@@ -272,7 +274,7 @@ func isNotScheduledSparkPod(pod *v1.Pod) bool {
 
 func availableResourcesPerInstanceGroup(
 	instanceGroupLabel string,
-	rrs []*v1beta1.ResourceReservation,
+	rrs []*v1beta2.ResourceReservation,
 	nodes []*v1.Node,
 	overhead resources.NodeGroupResources,
 	softReservationOverhead resources.NodeGroupResources) (map[instanceGroup]resources.NodeGroupResources, map[instanceGroup][]*v1.Node) {
@@ -299,7 +301,7 @@ func availableResourcesPerInstanceGroup(
 		instanceGroup := instanceGroup(n.Labels[instanceGroupLabel])
 		schedulableNodes[instanceGroup] = append(schedulableNodes[instanceGroup], n)
 	}
-	usages := resources.UsageForNodes(rrs)
+	usages := resources.UsageForNodesV1Beta2(rrs)
 	usages.Add(overhead)
 	usages.Add(softReservationOverhead)
 	availableResources := make(map[instanceGroup]resources.NodeGroupResources)
@@ -310,7 +312,7 @@ func availableResourcesPerInstanceGroup(
 }
 
 // patchResourceReservation gets a stale resource reservation and updates its status to reflect all given executors
-func (r *reconciler) patchResourceReservation(execs []*v1.Pod, rr *v1beta1.ResourceReservation) (*v1beta1.ResourceReservation, error) {
+func (r *reconciler) patchResourceReservation(execs []*v1.Pod, rr *v1beta2.ResourceReservation) (*v1beta2.ResourceReservation, error) {
 	for _, e := range execs {
 		for name, reservation := range rr.Spec.Reservations {
 			if reservation.Node != e.Spec.NodeName {
@@ -336,7 +338,7 @@ func (r *reconciler) constructResourceReservation(
 	ctx context.Context,
 	driver *v1.Pod,
 	executors []*v1.Pod,
-	instanceGroup instanceGroup) (*v1beta1.ResourceReservation, resources.NodeGroupResources, error) {
+	instanceGroup instanceGroup) (*v1beta2.ResourceReservation, resources.NodeGroupResources, error) {
 	applicationResources, err := sparkResources(ctx, driver)
 	if err != nil {
 		return nil, nil, err

--- a/internal/metrics/cache.go
+++ b/internal/metrics/cache.go
@@ -19,8 +19,8 @@ import (
 	"math"
 	"time"
 
-	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta1"
-	sparkschedulerlisters "github.com/palantir/k8s-spark-scheduler-lib/pkg/client/listers/sparkscheduler/v1beta1"
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta2"
+	sparkschedulerlisters "github.com/palantir/k8s-spark-scheduler-lib/pkg/client/listers/sparkscheduler/v1beta2"
 	"github.com/palantir/k8s-spark-scheduler/internal/cache"
 	"github.com/palantir/pkg/metrics"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -110,7 +110,7 @@ func (c *CacheMetrics) emitDemandMetrics(ctx context.Context) {
 	}
 }
 
-func reportDifference(ctx context.Context, cached, actual []*v1beta1.ResourceReservation) {
+func reportDifference(ctx context.Context, cached, actual []*v1beta2.ResourceReservation) {
 	cachedMap := toMap(cached)
 	for _, rr := range actual {
 		if _, ok := cachedMap[rr.UID]; !ok {
@@ -125,15 +125,15 @@ func reportDifference(ctx context.Context, cached, actual []*v1beta1.ResourceRes
 	}
 }
 
-func toMap(rrs []*v1beta1.ResourceReservation) map[types.UID]*v1beta1.ResourceReservation {
-	res := make(map[types.UID]*v1beta1.ResourceReservation, len(rrs))
+func toMap(rrs []*v1beta2.ResourceReservation) map[types.UID]*v1beta2.ResourceReservation {
+	res := make(map[types.UID]*v1beta2.ResourceReservation, len(rrs))
 	for _, rr := range rrs {
 		res[rr.UID] = rr
 	}
 	return res
 }
 
-func rrParams(rr *v1beta1.ResourceReservation) svc1log.Param {
+func rrParams(rr *v1beta2.ResourceReservation) svc1log.Param {
 	return svc1log.SafeParams(map[string]interface{}{
 		"resourceReservationName":      rr.Name,
 		"resourceReservationNamespace": rr.Namespace,

--- a/internal/metrics/usage.go
+++ b/internal/metrics/usage.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta1"
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta2"
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"github.com/palantir/k8s-spark-scheduler/internal/cache"
 	"github.com/palantir/pkg/metrics"
@@ -82,8 +82,8 @@ func (r *ResourceUsageReporter) doStart(ctx context.Context) error {
 	}
 }
 
-func (r *ResourceUsageReporter) report(ctx context.Context, nodes []*v1.Node, rrs []*v1beta1.ResourceReservation) {
-	resourceUsages := resources.UsageForNodes(rrs)
+func (r *ResourceUsageReporter) report(ctx context.Context, nodes []*v1.Node, rrs []*v1beta2.ResourceReservation) {
+	resourceUsages := resources.UsageForNodesV1Beta2(rrs)
 
 	tagsToDelete := make([]metrics.Tags, 0, len(resourceUsages))
 	metrics.FromContext(ctx).Each(func(name string, tags metrics.Tags, value metrics.MetricVal) {

--- a/vendor/github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta2/crd_resource_reservation.go
+++ b/vendor/github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta2/crd_resource_reservation.go
@@ -65,15 +65,6 @@ var v1beta2VersionDefinition = v1.CustomResourceDefinitionVersion{
 										},
 										"resources": {
 											Type:     "object",
-											Required: []string{string(ResourceCPU), string(ResourceMemory)},
-											Properties: map[string]v1.JSONSchemaProps{
-												string(ResourceCPU): {
-													Type: "string",
-												},
-												string(ResourceMemory): {
-													Type: "string",
-												},
-											},
 											AdditionalProperties: &v1.JSONSchemaPropsOrBool{
 												Schema: &v1.JSONSchemaProps{Type: "string"},
 											},
@@ -105,13 +96,6 @@ var resourceReservationDefinition = &v1.CustomResourceDefinition{
 			ShortNames: []string{"rr"},
 			Categories: []string{"all"},
 		},
-		Conversion: &v1.CustomResourceConversion{
-			Strategy: v1.WebhookConverter,
-			Webhook: &v1.WebhookConversion{
-				ConversionReviewVersions: []string{"v1", "v1beta1"},
-				ClientConfig:             nil,
-			},
-		},
 	},
 }
 
@@ -123,5 +107,12 @@ func ResourceReservationCustomResourceDefinition(webhook *v1.WebhookClientConfig
 		supportedVersions[i].Storage = false
 	}
 	resourceReservation.Spec.Versions = append(resourceReservation.Spec.Versions, supportedVersions...)
+	return resourceReservation
+}
+
+// ResourceReservationCustomResourceDefinitionNoWebhook returns the CRD definition for resource reservations
+func ResourceReservationCustomResourceDefinitionNoWebhook() *v1.CustomResourceDefinition {
+	resourceReservation := resourceReservationDefinition.DeepCopy()
+	resourceReservation.Spec.Versions = append(resourceReservation.Spec.Versions)
 	return resourceReservation
 }


### PR DESCRIPTION
This PR makes scheduler use v1beta2 of the resource reservation CRD.
It explicitly does not make use of GPUs or use them for scheduling.

TODO Before merging
 - [ ] Merge in webhooks and remove use of NoWebhook / Conversion CRD. (TODO in code)