### PR TITLE
Make verifyCRD compare spec versions for equality rather than storage versions

### DIFF
--- a/internal/crd/utils.go
+++ b/internal/crd/utils.go
@@ -44,15 +44,6 @@ func CheckCRDExists(ctx context.Context, crdName string, clientset apiextensions
 	return crd, false, nil
 }
 
-func getStorageVersion(crd *v1.CustomResourceDefinition) string {
-	for _, crdVersion := range crd.Spec.Versions {
-		if crdVersion.Storage {
-			return crdVersion.Name
-		}
-	}
-	return crd.Spec.Versions[0].Name
-}
-
 func emptyIfNil(x map[string]string) map[string]string {
 	if x == nil {
 		return map[string]string{}

--- a/internal/crd/utils_test.go
+++ b/internal/crd/utils_test.go
@@ -1,10 +1,25 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package crd
 
 import (
+	"testing"
+
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta1"
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta2"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"testing"
 )
 
 func Test_verifyCRD(t *testing.T) {


### PR DESCRIPTION
In its current state, we will not update the existing resource reservation v1beta1 CRD to v1beta2 because they both have the same storage version.

This change also means that in future we can modify the CRD in place without bumping version.