### PR TITLE
Loosen equality on crds.

### DIFF
--- a/internal/crd/utils.go
+++ b/internal/crd/utils.go
@@ -52,8 +52,12 @@ func emptyIfNil(x map[string]string) map[string]string {
 	return x
 }
 
+func annotationsAreEqual(existingAnnotations, desiredAnnotations map[string]string) bool {
+	return reflect.DeepEqual(emptyIfNil(existingAnnotations), emptyIfNil(desiredAnnotations))
+}
+
 func verifyCRD(existing, desired *v1.CustomResourceDefinition) bool {
-	return versionsAreEqual(existing.Spec.Versions, desired.Spec.Versions) && reflect.DeepEqual(emptyIfNil(existing.Annotations), emptyIfNil(desired.Annotations))
+	return versionsAreEqual(existing.Spec.Versions, desired.Spec.Versions) && annotationsAreEqual(existing.Annotations, desired.Annotations)
 }
 
 // getVersionWithName returns the CustomResourceDefinitionVersion with the specified name if it is found
@@ -66,6 +70,7 @@ func getVersionWithName(name string, versions []v1.CustomResourceDefinitionVersi
 	return v1.CustomResourceDefinitionVersion{}, false
 }
 
+// TODO(cbattarbee): Convert to map comparison
 func versionsAreEqual(existingVersions []v1.CustomResourceDefinitionVersion, desiredVersions []v1.CustomResourceDefinitionVersion) bool {
 	if len(existingVersions) != len(desiredVersions) {
 		return false


### PR DESCRIPTION
k8s sets additional fields when we submit our CRD to the api server, this causes issues when we come to compare local versions to it later. To get around this, we only compare the values that are necessary for us to determine whether or not to update. 

https://github.com/kubernetes-sigs/kubebuilder/issues/592