### PR TITLE
Add conversion strategy CRD verification

### DIFF
--- a/internal/crd/utils.go
+++ b/internal/crd/utils.go
@@ -56,8 +56,12 @@ func annotationsAreEqual(existingAnnotations, desiredAnnotations map[string]stri
 	return reflect.DeepEqual(emptyIfNil(existingAnnotations), emptyIfNil(desiredAnnotations))
 }
 
+func conversionStrategiesAreEqual(existingConversion, desiredConversion *v1.CustomResourceConversion) bool {
+	return reflect.DeepEqual(existingConversion, desiredConversion)
+}
+
 func verifyCRD(existing, desired *v1.CustomResourceDefinition) bool {
-	return versionsAreEqual(existing.Spec.Versions, desired.Spec.Versions) && annotationsAreEqual(existing.Annotations, desired.Annotations)
+	return versionsAreEqual(existing.Spec.Versions, desired.Spec.Versions) && annotationsAreEqual(existing.Annotations, desired.Annotations) && conversionStrategiesAreEqual(existing.Spec.Conversion, desired.Spec.Conversion)
 }
 
 // getVersionWithName returns the CustomResourceDefinitionVersion with the specified name if it is found

--- a/internal/crd/utils_test.go
+++ b/internal/crd/utils_test.go
@@ -22,6 +22,16 @@ import (
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
+var (
+	testConversionServiceNamespace           = "spark"
+	testConversionServiceName                = "conversion-service"
+	testConversionServiceDifferentName       = "conversion-service-different"
+	testConversionCABundle                   = []byte("conversion-service-ca-bundle")
+	testConversionDifferentCABundle          = []byte("conversion-service-ca-bundle-different")
+	testConversionServicePath                = "conversion-service-path"
+	testConversionServicePort          int32 = 2222
+)
+
 func Test_verifyCRD(t *testing.T) {
 	type args struct {
 		existing *v1.CustomResourceDefinition
@@ -53,6 +63,94 @@ func Test_verifyCRD(t *testing.T) {
 			args: args{
 				existing: v1beta1.ResourceReservationCustomResourceDefinition(),
 				desired:  v1beta2.ResourceReservationCustomResourceDefinition(nil, v1beta1.ResourceReservationCustomResourceDefinitionVersion()),
+			},
+			want: false,
+		},
+		{
+			name: "CRDs with identical conversion strategies do not verify.",
+			args: args{
+				existing: v1beta2.ResourceReservationCustomResourceDefinition(&v1.WebhookClientConfig{
+					Service: &v1.ServiceReference{
+						Namespace: testConversionServiceNamespace,
+						Name:      testConversionServiceName,
+						Path:      &testConversionServicePath,
+						Port:      &testConversionServicePort,
+					},
+					CABundle: testConversionCABundle,
+				}),
+				desired: v1beta2.ResourceReservationCustomResourceDefinition(&v1.WebhookClientConfig{
+					Service: &v1.ServiceReference{
+						Namespace: testConversionServiceNamespace,
+						Name:      testConversionServiceName,
+						Path:      &testConversionServicePath,
+						Port:      &testConversionServicePort,
+					},
+					CABundle: testConversionCABundle,
+				}),
+			},
+			want: true,
+		},
+		{
+			name: "CRDs with differing conversion services do not verify.",
+			args: args{
+				existing: v1beta2.ResourceReservationCustomResourceDefinition(&v1.WebhookClientConfig{
+					Service: &v1.ServiceReference{
+						Namespace: testConversionServiceNamespace,
+						Name:      testConversionServiceName,
+						Path:      &testConversionServicePath,
+						Port:      &testConversionServicePort,
+					},
+					CABundle: testConversionCABundle,
+				}),
+				desired: v1beta2.ResourceReservationCustomResourceDefinition(&v1.WebhookClientConfig{
+					Service: &v1.ServiceReference{
+						Namespace: testConversionServiceNamespace,
+						Name:      testConversionServiceDifferentName,
+						Path:      &testConversionServicePath,
+						Port:      &testConversionServicePort,
+					},
+					CABundle: testConversionCABundle,
+				}),
+			},
+			want: false,
+		},
+		{
+			name: "CRDs with differing cabundles do not verify.",
+			args: args{
+				existing: v1beta2.ResourceReservationCustomResourceDefinition(&v1.WebhookClientConfig{
+					Service: &v1.ServiceReference{
+						Namespace: testConversionServiceNamespace,
+						Name:      testConversionServiceName,
+						Path:      &testConversionServicePath,
+						Port:      &testConversionServicePort,
+					},
+					CABundle: testConversionCABundle,
+				}),
+				desired: v1beta2.ResourceReservationCustomResourceDefinition(&v1.WebhookClientConfig{
+					Service: &v1.ServiceReference{
+						Namespace: testConversionServiceNamespace,
+						Name:      testConversionServiceDifferentName,
+						Path:      &testConversionServicePath,
+						Port:      &testConversionServicePort,
+					},
+					CABundle: testConversionDifferentCABundle,
+				}),
+			},
+			want: false,
+		},
+		{
+			name: "CRD with no conversion strategy does not verify against a CRD that does.",
+			args: args{
+				existing: v1beta2.ResourceReservationCustomResourceDefinition(&v1.WebhookClientConfig{
+					Service: &v1.ServiceReference{
+						Namespace: testConversionServiceNamespace,
+						Name:      testConversionServiceName,
+						Path:      &testConversionServicePath,
+						Port:      &testConversionServicePort,
+					},
+					CABundle: testConversionCABundle,
+				}),
+				desired: v1beta2.ResourceReservationCustomResourceDefinition(nil),
 			},
 			want: false,
 		},


### PR DESCRIPTION
Previously scheduler would not update the resource reservation CRD if the conversion strategy was different. This is problematic in the case where the CRD conversion strategy has been edited by an entity other than scheduler.