### PR TITLE
Remove conversion webhook from scheduler

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -94,7 +94,7 @@ func initServer(ctx context.Context, info witchcraft.InitInfo) (func(), error) {
 		svc1log.FromContext(ctx).Error("Error building api extensions clientset: %s", svc1log.Stacktrace(err))
 		return nil, err
 	}
-	webhookClientConfig, err := conversionwebhook.InitializeCRDConversionWebhook(ctx, info.Router, install.Server,
+	webhookClientConfig, err := conversionwebhook.InitializeCRDConversionWebhook(ctx, install.Server,
 		install.WebhookServiceConfig.Namespace, install.WebhookServiceConfig.ServiceName, install.WebhookServiceConfig.ServicePort)
 	if err != nil {
 		svc1log.FromContext(ctx).Error("Error instantiating CRD conversion webhook: %s", svc1log.Stacktrace(err))

--- a/internal/conversionwebhook/resource_reservation.go
+++ b/internal/conversionwebhook/resource_reservation.go
@@ -23,10 +23,8 @@ import (
 	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	"github.com/palantir/witchcraft-go-server/config"
-	"github.com/palantir/witchcraft-go-server/wrouter"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
 )
 
 const (
@@ -45,33 +43,25 @@ func init() {
 // configuration pointing to the webhook.
 func InitializeCRDConversionWebhook(
 	ctx context.Context,
-	router wrouter.Router,
 	server config.Server,
 	schedulerNamespace string,
 	schedulerServiceName string,
 	schedulerServicePort int32,
 ) (*v1.WebhookClientConfig, error) {
-	err := addConversionWebhookRoute(ctx, router)
-	if err != nil {
-		return nil, err
-	}
-
-	path := filepath.Join(server.ContextPath, webhookPath)
-
 	if len(server.ClientCAFiles) == 0 {
-		return nil, werror.WrapWithContextParams(ctx, err, "No client CA bundle provided, can not generate conversion webhook client config")
+		return nil, werror.ErrorWithContextParams(ctx, "No client CA bundle provided, can not generate conversion webhook client config")
 	}
 
 	if len(server.ClientCAFiles) > 1 {
 		svc1log.FromContext(ctx).Warn("More than one client ca bundle provided, using the first one to generate " +
 			"the conversion webhook client config, it is likely that this scheduler is misconfigured.")
 	}
-
 	caBundle, err := ioutil.ReadFile(server.ClientCAFiles[0])
 	if err != nil {
 		return nil, werror.WrapWithContextParams(ctx, err, "Failed to read CA bundle from file, can not generate conversion webhook client config")
 	}
 
+	path := filepath.Join(server.ContextPath, webhookPath)
 	return &v1.WebhookClientConfig{
 		Service: &v1.ServiceReference{
 			Namespace: schedulerNamespace,
@@ -81,18 +71,4 @@ func InitializeCRDConversionWebhook(
 		},
 		CABundle: caBundle,
 	}, nil
-}
-
-// addConversionWebhookRoute adds resource reservation crd version conversion webhook
-func addConversionWebhookRoute(ctx context.Context, router wrouter.Router) error {
-	svc1log.FromContext(ctx).Info("Initializing resource reservation crd conversion webhook")
-	webhook := conversion.Webhook{}
-	err := webhook.InjectScheme(scheme)
-	if err != nil {
-		return werror.WrapWithContextParams(ctx, err, "failed to inject scheme into conversion webhook")
-	}
-	if err := router.Post(webhookPath, &webhook); err != nil {
-		return werror.WrapWithContextParams(ctx, err, "failed to add /convert route")
-	}
-	return nil
 }


### PR DESCRIPTION
The conversion webhook for resource reservations now runs standalone in a separate process, so we can stop serving the webhook from the scheduler process.