### PR TITLE
Add support for singleAZ scheduling and demand creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/palantir/k8s-spark-scheduler
 
 go 1.14
 
+replace github.com/palantir/k8s-spark-scheduler-lib => /Volumes/git/programming/go/src/github.com/palantir/k8s-spark-scheduler-lib
+
 require (
 	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7 // indirect
 	github.com/palantir/go-metrics v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -460,8 +460,6 @@ github.com/palantir/go-encrypted-config-value v1.1.0 h1:GwyTWSEthp3dRII2AL+lgdM5
 github.com/palantir/go-encrypted-config-value v1.1.0/go.mod h1:6c5zDN0XqZLxJiV3yLZmoEkUpaB4W3xJdKY6UPn24qI=
 github.com/palantir/go-metrics v1.1.0 h1:gf6W9EBvzREheH/3wNLPmJD8pe+xtag3TjePZe4hUTQ=
 github.com/palantir/go-metrics v1.1.0/go.mod h1:fRkuipBnsI4nD8Vd9UNcrUJvD8Y0wOJMSbicygcBrGs=
-github.com/palantir/k8s-spark-scheduler-lib v0.2.19 h1:jXIDXYz0I+8IfjO4ARac3+0tckfWiOInjMAaET7gplw=
-github.com/palantir/k8s-spark-scheduler-lib v0.2.19/go.mod h1:NfFt8Ct/Hb9uhsas1xvFSTWPR2Q/viCW209M/izsinY=
 github.com/palantir/pkg v1.0.1 h1:ZbGUcc14N7xcZSY9cehQoiHHTm/BAZO5RJdlsNEtSbk=
 github.com/palantir/pkg v1.0.1/go.mod h1:Eo6Jl0UXfT+65sLXJOcU9duu0WPvKsWFXCb0dE5VWZs=
 github.com/palantir/pkg/bytesbuffers v1.0.0/go.mod h1:JFWINutL8wfBpXOqastvJtuEXNEQhIVNnBVY0oeJFws=

--- a/internal/extender/binpack.go
+++ b/internal/extender/binpack.go
@@ -19,9 +19,10 @@ import (
 )
 
 const (
-	distributeEvenly   string = "distribute-evenly"
-	tightlyPack        string = "tightly-pack"
-	azAwareTightlyPack string = "az-aware-tightly-pack"
+	distributeEvenly    string = "distribute-evenly"
+	tightlyPack         string = "tightly-pack"
+	azAwareTightlyPack  string = "az-aware-tightly-pack"
+	singleAZTightlyPack string = "single-az-tightly-pack"
 )
 
 // Binpacker is a BinpackFunc with a known name
@@ -31,9 +32,10 @@ type Binpacker struct {
 }
 
 var binpackFunctions = map[string]*Binpacker{
-	tightlyPack:        {tightlyPack, binpack.TightlyPack},
-	distributeEvenly:   {distributeEvenly, binpack.DistributeEvenly},
-	azAwareTightlyPack: {azAwareTightlyPack, binpack.AzAwareTightlyPack},
+	tightlyPack:         {tightlyPack, binpack.TightlyPack},
+	distributeEvenly:    {distributeEvenly, binpack.DistributeEvenly},
+	azAwareTightlyPack:  {azAwareTightlyPack, binpack.AzAwareTightlyPack},
+	singleAZTightlyPack: {singleAZTightlyPack, binpack.SingleAZTightlyPack},
 }
 
 // SelectBinpacker selects the binpack function from the given name
@@ -43,4 +45,8 @@ func SelectBinpacker(name string) *Binpacker {
 		return binpackFunctions[distributeEvenly]
 	}
 	return binpacker
+}
+
+func DoesBinpackingScheduleInSingleAz(binpacker *Binpacker) bool {
+	return binpacker.Name == singleAZTightlyPack
 }

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -297,7 +297,7 @@ func (s *SparkSchedulerExtender) selectDriverNode(ctx context.Context, driver *v
 		}
 		ok := s.fitEarlierDrivers(ctx, queuedDrivers, driverNodeNames, executorNodeNames, availableNodesSchedulingMetadata)
 		if !ok {
-			s.createDemandForApplication(ctx, driver, applicationResources)
+			s.createDemandForApplication(ctx, driver, applicationResources, DoesBinpackingScheduleInSingleAz(s.binpacker))
 			return "", failureEarlierDriver, werror.Error("earlier drivers do not fit to the cluster")
 		}
 	}
@@ -322,7 +322,7 @@ func (s *SparkSchedulerExtender) selectDriverNode(ctx context.Context, driver *v
 		svc1log.SafeParam("executorNodes", executorNodes),
 		svc1log.SafeParam("binpacker", s.binpacker.Name))
 	if !hasCapacity {
-		s.createDemandForApplication(ctx, driver, applicationResources)
+		s.createDemandForApplication(ctx, driver, applicationResources, DoesBinpackingScheduleInSingleAz(s.binpacker))
 		return "", failureFit, werror.Error("application does not fit to the cluster")
 	}
 	s.removeDemandIfExists(ctx, driver)

--- a/vendor/github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/scaler/v1alpha2/crd_demand.go
+++ b/vendor/github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/scaler/v1alpha2/crd_demand.go
@@ -51,6 +51,10 @@ var (
 								Format:   "date-time",
 								Nullable: true,
 							},
+							"fulfilled-zone": {
+								Type:     "string",
+								Nullable: true,
+							},
 						},
 					},
 					"spec": {
@@ -62,6 +66,9 @@ var (
 								MinLength: &oneInt,
 							},
 							"is-long-lived": {
+								Type: "boolean",
+							},
+							"enforce-single-zone-scheduling": {
 								Type: "boolean",
 							},
 							"units": {
@@ -104,6 +111,16 @@ var (
 			Type:        "boolean",
 			JSONPath:    ".spec.is-long-lived",
 			Description: "The lifecycle description of the Demand request",
+		}, {
+			Name:        "single zone",
+			Type:        "boolean",
+			JSONPath:    ".spec.enforce-single-zone-scheduling",
+			Description: "The zone distribution description of the Demand request",
+		}, {
+			Name:        "fulfilled zone",
+			Type:        "boolean",
+			JSONPath:    ".status.fulfilled-zone",
+			Description: "The zone scaled to satisfy the single zone Demand request",
 		}, {
 			Name:        "units",
 			Type:        "string",

--- a/vendor/github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/scaler/v1alpha2/types_demand.go
+++ b/vendor/github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/scaler/v1alpha2/types_demand.go
@@ -85,6 +85,9 @@ type DemandSpec struct {
 	// an amount of compute resources that is left unused
 	// but ready for quick reservation should there be need.
 	IsLongLived bool `json:"is-long-lived"`
+	// EnforceSingleZoneScheduling indicates this demand must
+	// be satisfied in a single zone.
+	EnforceSingleZoneScheduling bool `json:"enforce-single-zone-scheduling"`
 }
 
 // DemandStatus represents the status a demand object is in
@@ -95,6 +98,9 @@ type DemandStatus struct {
 	// If left empty, defaults to the creation time of the demand.
 	// +optional
 	LastTransitionTime metav1.Time `json:"last-transition-time,omitempty"`
+	// FulfilledZone is the zone that was scaled up to satisfy this demand. Note this is only populated for
+	// single zone demands, and it does not guarantee that the demand resources will be scheduled in this zone.
+	FulfilledZone string `json:"fulfilled-zone,omitempty"`
 }
 
 // ResourceList is a set of (resource name, quantity) pairs.

--- a/vendor/github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta2/crd_resource_reservation.go
+++ b/vendor/github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta2/crd_resource_reservation.go
@@ -23,7 +23,7 @@ import (
 var v1beta2VersionDefinition = v1.CustomResourceDefinitionVersion{
 	Name:    "v1beta2",
 	Served:  true,
-	Storage: false,
+	Storage: true,
 	AdditionalPrinterColumns: []v1.CustomResourceColumnDefinition{{
 		Name:        "driver",
 		Type:        "string",

--- a/vendor/github.com/palantir/k8s-spark-scheduler-lib/pkg/binpack/single_az_pack_tightly.go
+++ b/vendor/github.com/palantir/k8s-spark-scheduler-lib/pkg/binpack/single_az_pack_tightly.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binpack
+
+import (
+	"context"
+
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
+)
+
+// SingleAZTightlyPack is a SparkBinPackFunction that tries to put the driver pod
+// to as prior nodes as possible before trying to tightly pack executors
+// while also ensuring that we can fit everything in a single AZ.
+// If it cannot fit into a single AZ binpacking fails
+var SingleAZTightlyPack = SparkBinPackFunction(func(
+	ctx context.Context,
+	driverResources, executorResources *resources.Resources,
+	executorCount int,
+	driverNodePriorityOrder, executorNodePriorityOrder []string,
+	nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata) (string, []string, bool) {
+
+	driverNodePriorityOrderByZone := groupNodesByZone(driverNodePriorityOrder, nodesSchedulingMetadata)
+	executorNodePriorityOrderByZone := groupNodesByZone(executorNodePriorityOrder, nodesSchedulingMetadata)
+
+	for zone, driverNodePriorityOrderForZone := range driverNodePriorityOrderByZone {
+		executorNodePriorityOrderForZone, ok := executorNodePriorityOrderByZone[zone]
+		if !ok {
+			continue
+		}
+		driverNode, executorNodes, hasCapacity := SparkBinPack(ctx, driverResources, executorResources, executorCount, driverNodePriorityOrderForZone, executorNodePriorityOrderForZone, nodesSchedulingMetadata, tightlyPackExecutors)
+		if hasCapacity {
+			return driverNode, executorNodes, hasCapacity
+		}
+	}
+	return "", nil, false
+})
+
+func groupNodesByZone(nodeNames []string, nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata) map[string][]string {
+	nodeNamesByZone := make(map[string][]string)
+	for _, nodeName := range nodeNames {
+		nodesSchedulingMetadata, ok := nodesSchedulingMetadata[nodeName]
+		if !ok {
+			continue
+		}
+		zoneLabel := nodesSchedulingMetadata.ZoneLabel
+		nodeNamesByZone[zoneLabel] = append(nodeNamesByZone[zoneLabel], nodeName)
+	}
+	return nodeNamesByZone
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -75,7 +75,7 @@ github.com/palantir/go-encrypted-config-value/encryption
 # github.com/palantir/go-metrics v1.1.0
 ## explicit
 github.com/palantir/go-metrics
-# github.com/palantir/k8s-spark-scheduler-lib v0.2.19
+# github.com/palantir/k8s-spark-scheduler-lib v0.2.19 => /Volumes/git/programming/go/src/github.com/palantir/k8s-spark-scheduler-lib
 ## explicit
 github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/scaler/v1alpha1
 github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/scaler/v1alpha2
@@ -734,6 +734,7 @@ sigs.k8s.io/controller-runtime/pkg/webhook/conversion
 sigs.k8s.io/structured-merge-diff/v3/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
+# github.com/palantir/k8s-spark-scheduler-lib => /Volumes/git/programming/go/src/github.com/palantir/k8s-spark-scheduler-lib
 # k8s.io/api => k8s.io/api v0.18.8
 # k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.18.8
 # k8s.io/apimachinery => k8s.io/apimachinery v0.18.8


### PR DESCRIPTION
As a follow up to https://github.com/palantir/k8s-spark-scheduler-lib/pull/71 and https://github.com/palantir/k8s-spark-scheduler-lib/pull/70 this PR will allow scheduler to binpack pods into a single AZ and create demands that will be fulfilled in a single AZ.

The motivation being that applications scheduled in the same AZ will not incur cross AZ networking costs

## TODO
* [] Remove local replace once prior kss lib PR is merged 

