### PR TITLE
Upgrade base docker image version for kss and kscw to alpine 3.16

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.16
 
 ENV SERVICE_HOME=/opt/palantir/services/spark-scheduler
 ENV SPARK_SCHEDULER_STARTUP_CONFIG=$SERVICE_HOME/var/conf/install.yml

--- a/spark-scheduler-conversion-webhook/docker/Dockerfile
+++ b/spark-scheduler-conversion-webhook/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.16
 
 ENV SERVICE_HOME=/opt/palantir/services/spark-scheduler-conversion-webhook
 ENV SPARK_SCHEDULER_STARTUP_CONFIG=$SERVICE_HOME/var/conf/install.yml


### PR DESCRIPTION
Upgrades base docker image from Alpine 3.7 to Alpine 3.16 for both spark-scheduler and the conversion webhook.