### PR TITLE
Make unschedulable pod timeout duration configurable

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -232,6 +232,7 @@ func initServer(ctx context.Context, info witchcraft.InitInfo) (func(), error) {
 		kubeClient.CoreV1(),
 		overheadComputer,
 		binpacker,
+		install.UnschedulablePodTimeoutDuration,
 	)
 
 	resourceReservationCache.Run(ctx)

--- a/config/config.go
+++ b/config/config.go
@@ -22,16 +22,17 @@ import (
 
 // Install contains the install time configuration of the server and kubernetes dependency
 type Install struct {
-	config.Install     `yaml:",inline"`
-	config.Runtime     `yaml:",inline"`
-	Kubeconfig         string            `yaml:"kube-config,omitempty"`
-	FIFO               bool              `yaml:"fifo,omitempty"`
-	FifoConfig         FifoConfig        `yaml:"fifo-config,omitempty"`
-	QPS                float32           `yaml:"qps,omitempty"`
-	Burst              int               `yaml:"burst,omitempty"`
-	BinpackAlgo        string            `yaml:"binpack,omitempty"`
-	InstanceGroupLabel string            `yaml:"instance-group-label,omitempty"`
-	AsyncClientConfig  AsyncClientConfig `yaml:"async-client-config,omitempty"`
+	config.Install                  `yaml:",inline"`
+	config.Runtime                  `yaml:",inline"`
+	Kubeconfig                      string            `yaml:"kube-config,omitempty"`
+	FIFO                            bool              `yaml:"fifo,omitempty"`
+	FifoConfig                      FifoConfig        `yaml:"fifo-config,omitempty"`
+	QPS                             float32           `yaml:"qps,omitempty"`
+	Burst                           int               `yaml:"burst,omitempty"`
+	BinpackAlgo                     string            `yaml:"binpack,omitempty"`
+	InstanceGroupLabel              string            `yaml:"instance-group-label,omitempty"`
+	AsyncClientConfig               AsyncClientConfig `yaml:"async-client-config,omitempty"`
+	UnschedulablePodTimeoutDuration time.Duration     `yaml:"unschedulable-pod-timeout-duration,omitempty"`
 
 	// Deprecated: assumed true, value not used
 	UseExperimentalHostPriorities bool `yaml:"use-experimental-host-priorities,omitempty"`

--- a/docker/var/conf/install.yml
+++ b/docker/var/conf/install.yml
@@ -3,6 +3,7 @@ server:
   management-port: 8484
   context-path: /spark-scheduler
 fifo: true
+unschedulable-pod-timeout-duration: 10m
 logging:
   level: info
   output: STDOUT

--- a/hack/dev/generate-certs.sh
+++ b/hack/dev/generate-certs.sh
@@ -10,7 +10,7 @@ mkdir -p $TMP_DIR
 openssl genrsa -out "${TMP_DIR}/rootCA.key" 2048
 
 # Generate the root ca cert from the key
-openssl req -batch -x509 -sha256 -new -nodes -key ${TMP_DIR}/rootCA.key -days 3650 -out ${TMP_DIR}/rootCA.crt
+openssl req -batch -x509 -sha256 -new -nodes -key ${TMP_DIR}/rootCA.key -days 3650 -out ${TMP_DIR}/rootCA.crt -config ${SCRIPT_DIR}/cert.conf
 
 # Generate the signing request for the witchcraft ssl cert as well as the private key
 openssl req -new -nodes -newkey rsa:2048 -keyout ${TMP_DIR}/spark-scheduler.key -out ${TMP_DIR}/spark-scheduler.csr -config ${SCRIPT_DIR}/cert.conf -extensions 'v3_req'

--- a/internal/extender/extendertest/extender_test_utils.go
+++ b/internal/extender/extendertest/extender_test_utils.go
@@ -156,7 +156,8 @@ func NewTestExtender(objects ...runtime.Object) (*Harness, error) {
 		podLister,
 		fakeKubeClient.CoreV1(),
 		overheadComputer,
-		binpacker)
+		binpacker,
+		installConfig.UnschedulablePodTimeoutDuration)
 
 	return &Harness{
 		Extender:                 sparkSchedulerExtender,

--- a/internal/extender/unschedulablepods.go
+++ b/internal/extender/unschedulablepods.go
@@ -109,6 +109,8 @@ func (u *UnschedulablePodMarker) scanForUnschedulablePods(ctx context.Context) {
 				svc1log.SafeParam("podNamespace", pod.Namespace),
 				svc1log.SafeParam("timeoutDuration", u.timeoutDuration))
 
+			svc1log.FromContext(ctx).Info("Evaluating pod")
+
 			exceedsCapacity, err := u.DoesPodExceedClusterCapacity(ctx, pod)
 			if err != nil {
 				svc1log.FromContext(ctx).Error("failed to check if pod was unschedulable",

--- a/internal/extender/unschedulablepods.go
+++ b/internal/extender/unschedulablepods.go
@@ -106,7 +106,8 @@ func (u *UnschedulablePodMarker) scanForUnschedulablePods(ctx context.Context) {
 			ctx = svc1log.WithLoggerParams(
 				ctx,
 				svc1log.SafeParam("podName", pod.Name),
-				svc1log.SafeParam("podNamespace", pod.Namespace))
+				svc1log.SafeParam("podNamespace", pod.Namespace),
+				svc1log.SafeParam("timeoutDuration", u.timeoutDuration))
 
 			exceedsCapacity, err := u.DoesPodExceedClusterCapacity(ctx, pod)
 			if err != nil {

--- a/internal/extender/unschedulablepods.go
+++ b/internal/extender/unschedulablepods.go
@@ -107,7 +107,7 @@ func (u *UnschedulablePodMarker) scanForUnschedulablePods(ctx context.Context) {
 				ctx,
 				svc1log.SafeParam("podName", pod.Name),
 				svc1log.SafeParam("podNamespace", pod.Namespace),
-				svc1log.SafeParam("timeoutDuration", u.timeoutDuration))
+				svc1log.SafeParam("timeUntilTimeout", now.Sub(pod.CreationTimestamp.Time.Add(u.timeoutDuration))))
 
 			exceedsCapacity, err := u.DoesPodExceedClusterCapacity(ctx, pod)
 			if err != nil {

--- a/internal/extender/unschedulablepods.go
+++ b/internal/extender/unschedulablepods.go
@@ -107,7 +107,7 @@ func (u *UnschedulablePodMarker) scanForUnschedulablePods(ctx context.Context) {
 				ctx,
 				svc1log.SafeParam("podName", pod.Name),
 				svc1log.SafeParam("podNamespace", pod.Namespace),
-				svc1log.SafeParam("timeUntilTimeout", now.Sub(pod.CreationTimestamp.Time.Add(u.timeoutDuration))))
+				svc1log.SafeParam("timeUntilTimeout", pod.CreationTimestamp.Time.Add(u.timeoutDuration).Sub(now)))
 
 			exceedsCapacity, err := u.DoesPodExceedClusterCapacity(ctx, pod)
 			if err != nil {

--- a/internal/extender/unschedulablepods.go
+++ b/internal/extender/unschedulablepods.go
@@ -68,7 +68,7 @@ func NewUnschedulablePodMarker(
 		coreClient:       coreClient,
 		overheadComputer: overheadComputer,
 		binpacker:        binpacker,
-		timeoutDuration:  timeoutDuration,
+		timeoutDuration:  10 * time.Minute,
 	}
 }
 
@@ -108,8 +108,6 @@ func (u *UnschedulablePodMarker) scanForUnschedulablePods(ctx context.Context) {
 				svc1log.SafeParam("podName", pod.Name),
 				svc1log.SafeParam("podNamespace", pod.Namespace),
 				svc1log.SafeParam("timeoutDuration", u.timeoutDuration))
-
-			svc1log.FromContext(ctx).Info("Evaluating pod", svc1log.SafeParam("timeoutDurationMinutes", u.timeoutDuration.Minutes()))
 
 			exceedsCapacity, err := u.DoesPodExceedClusterCapacity(ctx, pod)
 			if err != nil {

--- a/internal/extender/unschedulablepods.go
+++ b/internal/extender/unschedulablepods.go
@@ -109,7 +109,7 @@ func (u *UnschedulablePodMarker) scanForUnschedulablePods(ctx context.Context) {
 				svc1log.SafeParam("podNamespace", pod.Namespace),
 				svc1log.SafeParam("timeoutDuration", u.timeoutDuration))
 
-			svc1log.FromContext(ctx).Info("Evaluating pod")
+			svc1log.FromContext(ctx).Info("Evaluating pod", svc1log.SafeParam("timeoutDurationMinutes", u.timeoutDuration.Minutes()))
 
 			exceedsCapacity, err := u.DoesPodExceedClusterCapacity(ctx, pod)
 			if err != nil {

--- a/internal/extender/unschedulablepods.go
+++ b/internal/extender/unschedulablepods.go
@@ -58,7 +58,7 @@ func NewUnschedulablePodMarker(
 	binpacker *Binpacker,
 	timeoutDuration time.Duration) *UnschedulablePodMarker {
 
-	if timeoutDuration == 0 {
+	if timeoutDuration <= 0 {
 		timeoutDuration = 10 * time.Minute
 	}
 

--- a/internal/extender/unschedulablepods.go
+++ b/internal/extender/unschedulablepods.go
@@ -68,7 +68,7 @@ func NewUnschedulablePodMarker(
 		coreClient:       coreClient,
 		overheadComputer: overheadComputer,
 		binpacker:        binpacker,
-		timeoutDuration:  10 * time.Minute,
+		timeoutDuration:  timeoutDuration,
 	}
 }
 


### PR DESCRIPTION
Pods are currently marked as "exceeds capacity" if they are unschedulable for 10 mins. This PR will make this duration configurable to account for environments where scheduler needs to wait for longer before giving up on scheduling a pod.