### PR TITLE
Log spark app id when scheduling pod

### DIFF
--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -126,8 +126,10 @@ func (s *SparkSchedulerExtender) Predicate(ctx context.Context, args schedulerap
 	if !success {
 		instanceGroup = ""
 	}
+	sparkAppId := args.Pod.Labels[common.SparkAppIDLabel]
 	params["podSparkRole"] = role
 	params["instanceGroup"] = instanceGroup
+	params["sparkAppId"] = sparkAppId
 
 	timer := metrics.NewScheduleTimer(ctx, instanceGroup, args.Pod)
 	logger.Info("starting scheduling pod")

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -126,10 +126,10 @@ func (s *SparkSchedulerExtender) Predicate(ctx context.Context, args schedulerap
 	if !success {
 		instanceGroup = ""
 	}
-	sparkAppId := args.Pod.Labels[common.SparkAppIDLabel]
+	sparkAppID := args.Pod.Labels[common.SparkAppIDLabel]
 	params["podSparkRole"] = role
 	params["instanceGroup"] = instanceGroup
-	params["sparkAppId"] = sparkAppId
+	params["sparkAppID"] = sparkAppID
 
 	timer := metrics.NewScheduleTimer(ctx, instanceGroup, args.Pod)
 	logger.Info("starting scheduling pod")


### PR DESCRIPTION
We now log the spark app id when scheduling a pod, this makes it easier to find scheduling log lines for specific applications and makes debugging easier.

This label is always guaranteed to be set or else scheduling will fail later when we create resource reservations as the name of the resource reservation is equal to the spark-app-id label value.