### PR TITLE
Make node sorting deterministic as it otherwise causes flakes

### DIFF
--- a/internal/sort/nodesorting.go
+++ b/internal/sort/nodesorting.go
@@ -78,17 +78,20 @@ func resourcesLessThan(left *resources.Resources, right *resources.Resources) bo
 	return left.CPU.Cmp(right.CPU) == -1
 }
 
-// Sort first by AZ priority and then by resources on the node
-func scheduleContextLessThan(sc map[string]scheduleContext, left, right string) bool {
-	if sc[left].azPriority != sc[right].azPriority {
-		return sc[left].azPriority < sc[right].azPriority
+// Sort first by AZ priority, then by resources on the node, then by node name
+func scheduleContextLessThan(scheduleContexts map[string]scheduleContext, left, right string) bool {
+	leftSc := scheduleContexts[left]
+	rightSc := scheduleContexts[right]
+
+	if leftSc.azPriority != rightSc.azPriority {
+		return leftSc.azPriority < rightSc.azPriority
 	}
 
-	if sc[left].nodeResources.Eq(sc[right].nodeResources) {
-		return left < right
+	if !leftSc.nodeResources.Eq(rightSc.nodeResources) {
+		return resourcesLessThan(leftSc.nodeResources, rightSc.nodeResources)
 	}
 
-	return resourcesLessThan(sc[left].nodeResources, sc[right].nodeResources)
+	return left < right
 }
 
 func getNodeNamesInPriorityOrder(nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata) []string {

--- a/internal/sort/nodesorting.go
+++ b/internal/sort/nodesorting.go
@@ -79,11 +79,16 @@ func resourcesLessThan(left *resources.Resources, right *resources.Resources) bo
 }
 
 // Sort first by AZ priority and then by resources on the node
-func scheduleContextLessThan(left scheduleContext, right scheduleContext) bool {
-	if left.azPriority != right.azPriority {
-		return left.azPriority < right.azPriority
+func scheduleContextLessThan(sc map[string]scheduleContext, left, right string) bool {
+	if sc[left].azPriority != sc[right].azPriority {
+		return sc[left].azPriority < sc[right].azPriority
 	}
-	return resourcesLessThan(left.nodeResources, right.nodeResources)
+
+	if sc[left].nodeResources.Eq(sc[right].nodeResources) {
+		return left < right
+	}
+
+	return resourcesLessThan(sc[left].nodeResources, sc[right].nodeResources)
 }
 
 func getNodeNamesInPriorityOrder(nodesSchedulingMetadata resources.NodeGroupSchedulingMetadata) []string {
@@ -108,7 +113,7 @@ func getNodeNamesInPriorityOrder(nodesSchedulingMetadata resources.NodeGroupSche
 	}
 
 	sort.Slice(nodeNames, func(i, j int) bool {
-		return scheduleContextLessThan(scheduleContexts[nodeNames[i]], scheduleContexts[nodeNames[j]])
+		return scheduleContextLessThan(scheduleContexts, nodeNames[i], nodeNames[j])
 	})
 
 	return nodeNames

--- a/internal/sort/nodesorting_test.go
+++ b/internal/sort/nodesorting_test.go
@@ -74,12 +74,23 @@ func TestScheduleContextSorting(t *testing.T) {
 		nodeResources: moreResources,
 	}
 
-	if scheduleContextLessThan(lowerAzPriority, base) || !scheduleContextLessThan(base, lowerAzPriority) {
+	scheduleContexts := map[string]scheduleContext{
+		"base":  base,
+		"same":  base,
+		"lower": lowerAzPriority,
+		"more":  moreNodeResources,
+	}
+
+	if scheduleContextLessThan(scheduleContexts, "lower", "base") || !scheduleContextLessThan(scheduleContexts, "base", "lower") {
 		t.Error("Nodes should be sorted by the priority of the AZ they belong to, ascending")
 	}
 
-	if scheduleContextLessThan(moreNodeResources, base) || !scheduleContextLessThan(base, moreNodeResources) {
+	if scheduleContextLessThan(scheduleContexts, "more", "base") || !scheduleContextLessThan(scheduleContexts, "base", "more") {
 		t.Error("If AZ priority is equal, nodes should be sorted by the available resources, ascending")
+	}
+
+	if scheduleContextLessThan(scheduleContexts, "base", "same") || !scheduleContextLessThan(scheduleContexts, "same", "base") {
+		t.Error("If everything is equal, nodes should be sorted by node name, ascending")
 	}
 }
 

--- a/internal/sort/nodesorting_test.go
+++ b/internal/sort/nodesorting_test.go
@@ -61,35 +61,36 @@ func TestScheduleContextSorting(t *testing.T) {
 		CPU:    one,
 		Memory: two,
 	}
-	base := scheduleContext{
+	base1 := scheduleContext{
 		azPriority:    0,
 		nodeResources: lessResources,
+		nodeName:      "base1",
+	}
+	base2 := scheduleContext{
+		azPriority:    0,
+		nodeResources: lessResources,
+		nodeName:      "base2",
 	}
 	lowerAzPriority := scheduleContext{
 		azPriority:    1,
 		nodeResources: lessResources,
+		nodeName:      "lower",
 	}
 	moreNodeResources := scheduleContext{
 		azPriority:    0,
 		nodeResources: moreResources,
+		nodeName:      "more",
 	}
 
-	scheduleContexts := map[string]scheduleContext{
-		"base1": base,
-		"base2": base,
-		"lower": lowerAzPriority,
-		"more":  moreNodeResources,
-	}
-
-	if scheduleContextLessThan(scheduleContexts, "lower", "base1") || !scheduleContextLessThan(scheduleContexts, "base1", "lower") {
+	if scheduleContextLessThan(lowerAzPriority, base1) || !scheduleContextLessThan(base1, lowerAzPriority) {
 		t.Error("Nodes should be sorted by the priority of the AZ they belong to, ascending")
 	}
 
-	if scheduleContextLessThan(scheduleContexts, "more", "base1") || !scheduleContextLessThan(scheduleContexts, "base1", "more") {
+	if scheduleContextLessThan(moreNodeResources, base1) || !scheduleContextLessThan(base1, moreNodeResources) {
 		t.Error("If AZ priority is equal, nodes should be sorted by the available resources, ascending")
 	}
 
-	if scheduleContextLessThan(scheduleContexts, "base2", "base1") || !scheduleContextLessThan(scheduleContexts, "base1", "base2") {
+	if scheduleContextLessThan(base2, base1) || !scheduleContextLessThan(base1, base2) {
 		t.Error("If everything is equal, nodes should be sorted by node name, ascending")
 	}
 }

--- a/internal/sort/nodesorting_test.go
+++ b/internal/sort/nodesorting_test.go
@@ -75,21 +75,21 @@ func TestScheduleContextSorting(t *testing.T) {
 	}
 
 	scheduleContexts := map[string]scheduleContext{
-		"base":  base,
-		"same":  base,
+		"base1": base,
+		"base2": base,
 		"lower": lowerAzPriority,
 		"more":  moreNodeResources,
 	}
 
-	if scheduleContextLessThan(scheduleContexts, "lower", "base") || !scheduleContextLessThan(scheduleContexts, "base", "lower") {
+	if scheduleContextLessThan(scheduleContexts, "lower", "base1") || !scheduleContextLessThan(scheduleContexts, "base1", "lower") {
 		t.Error("Nodes should be sorted by the priority of the AZ they belong to, ascending")
 	}
 
-	if scheduleContextLessThan(scheduleContexts, "more", "base") || !scheduleContextLessThan(scheduleContexts, "base", "more") {
+	if scheduleContextLessThan(scheduleContexts, "more", "base1") || !scheduleContextLessThan(scheduleContexts, "base1", "more") {
 		t.Error("If AZ priority is equal, nodes should be sorted by the available resources, ascending")
 	}
 
-	if scheduleContextLessThan(scheduleContexts, "same", "base") || !scheduleContextLessThan(scheduleContexts, "base", "same") {
+	if scheduleContextLessThan(scheduleContexts, "base2", "base1") || !scheduleContextLessThan(scheduleContexts, "base1", "base2") {
 		t.Error("If everything is equal, nodes should be sorted by node name, ascending")
 	}
 }

--- a/internal/sort/nodesorting_test.go
+++ b/internal/sort/nodesorting_test.go
@@ -89,7 +89,7 @@ func TestScheduleContextSorting(t *testing.T) {
 		t.Error("If AZ priority is equal, nodes should be sorted by the available resources, ascending")
 	}
 
-	if scheduleContextLessThan(scheduleContexts, "base", "same") || !scheduleContextLessThan(scheduleContexts, "same", "base") {
+	if scheduleContextLessThan(scheduleContexts, "same", "base") || !scheduleContextLessThan(scheduleContexts, "base", "same") {
 		t.Error("If everything is equal, nodes should be sorted by node name, ascending")
 	}
 }


### PR DESCRIPTION
All things being equal, compare node names to break ties.

Example flake: https://app.circleci.com/pipelines/github/palantir/k8s-spark-scheduler/1857/workflows/017da816-ce66-4a03-898d-36ddfbe3d850/jobs/6103

Confirmed this works by running the test in a loop:
* with current logic it yields several failures
* with this PR it's all ✅ 