### PR TITLE
Deduplicate driver pod demands

### DIFF
--- a/internal/extender/demand.go
+++ b/internal/extender/demand.go
@@ -83,7 +83,7 @@ func (s *SparkSchedulerExtender) createDemandForApplicationInAnyZone(ctx context
 	if !s.demands.CRDExists() {
 		return
 	}
-	s.createDemand(ctx, driverPod, demandResources(applicationResources), nil)
+	s.createDemand(ctx, driverPod, demandResourcesForApplication(driverPod, applicationResources), nil)
 }
 
 func (s *SparkSchedulerExtender) createDemand(ctx context.Context, pod *v1.Pod, demandUnits []demandapi.DemandUnit, zone *demandapi.Zone) {
@@ -169,7 +169,7 @@ func (s *SparkSchedulerExtender) newDemand(pod *v1.Pod, instanceGroup string, un
 	}, nil
 }
 
-func demandResources(applicationResources *sparkApplicationResources) []demandapi.DemandUnit {
+func demandResourcesForApplication(driverPod *v1.Pod, applicationResources *sparkApplicationResources) []demandapi.DemandUnit {
 	demandUnits := []demandapi.DemandUnit{
 		{
 			Count: 1,
@@ -177,6 +177,10 @@ func demandResources(applicationResources *sparkApplicationResources) []demandap
 				demandapi.ResourceCPU:       applicationResources.driverResources.CPU,
 				demandapi.ResourceMemory:    applicationResources.driverResources.Memory,
 				demandapi.ResourceNvidiaGPU: applicationResources.driverResources.NvidiaGPU,
+			},
+			// By specifying the pod driver pod here, we don't duplicate the resources of the pod with the created demand
+			PodNamesByNamespace: map[string][]string{
+				driverPod.Namespace: {driverPod.Name},
 			},
 		},
 	}

--- a/internal/extender/demand_test.go
+++ b/internal/extender/demand_test.go
@@ -1,0 +1,62 @@
+package extender
+
+import (
+	demandapi "github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/scaler/v1alpha2"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"testing"
+)
+
+var testResource = createResources(1, 2432*1024*1024, 1)
+
+var testResources = &sparkApplicationResources{
+	driverResources:   testResource,
+	executorResources: testResource,
+	minExecutorCount:  0,
+	maxExecutorCount:  0,
+}
+var testPod = &v1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "test-name",
+		Namespace: "test-namespace",
+	},
+}
+
+func Test_demandResourcesForApplication(t *testing.T) {
+	type args struct {
+		driverPod            *v1.Pod
+		applicationResources *sparkApplicationResources
+	}
+	var tests = []struct {
+		name string
+		args args
+		want []demandapi.DemandUnit
+	}{
+		{
+			name: "Demand created for application contains pod to deduplicate against",
+			args: args{
+				driverPod:            testPod,
+				applicationResources: testResources,
+			},
+			want: []demandapi.DemandUnit{
+				{
+					Resources: demandapi.ResourceList{
+						demandapi.ResourceCPU:       testResources.driverResources.CPU,
+						demandapi.ResourceMemory:    testResources.driverResources.Memory,
+						demandapi.ResourceNvidiaGPU: testResources.driverResources.NvidiaGPU,
+					},
+					Count:               1,
+					PodNamesByNamespace: map[string][]string{"test-namespace": {"test-name"}},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := demandResourcesForApplication(tt.args.driverPod, tt.args.applicationResources); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("demandResourcesForApplication() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Before this PR
Before this PR we would make demands for the entire application: The driver pod + all executor pods. This was a problem because the driver pod also existed in the cluster as well as the demand which was needed to provide scale up signal in a particular AZ.

## After this PR
This PR adds the driver pod to `PodNamesByNamespace` which allows scaling infrastructure to to deduplicate driver pods and their associated demands

==COMMIT_MSG==
Deduplicate driver pod demands
==COMMIT_MSG==
