### PR TITLE
Point single-az-minimal-fragmentation to the correct function

### DIFF
--- a/internal/extender/binpack.go
+++ b/internal/extender/binpack.go
@@ -41,7 +41,7 @@ var binpackFunctions = map[string]*Binpacker{
 	distributeEvenly:             {distributeEvenly, binpack.DistributeEvenly, false},
 	azAwareTightlyPack:           {azAwareTightlyPack, binpack.AzAwareTightlyPack, false},
 	singleAZTightlyPack:          {singleAZTightlyPack, binpack.SingleAZTightlyPack, true},
-	singleAzMinimalFragmentation: {singleAzMinimalFragmentation, binpack.MinimalFragmentation, true},
+	singleAzMinimalFragmentation: {singleAzMinimalFragmentation, binpack.SingleAZMinimalFragmentation, true},
 }
 
 // SelectBinpacker selects the binpack function from the given name


### PR DESCRIPTION
## Before this PR

`single-az-minimal-fragmentation` isn't single AZ

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
`single-az-minimal-fragmentation` only schedules in a single AZ
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
