### PR TITLE
Bump spark-scheduler-lib to 0.15.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/palantir/go-metrics v1.1.1
-	github.com/palantir/k8s-spark-scheduler-lib v0.13.0
+	github.com/palantir/k8s-spark-scheduler-lib v0.15.0
 	github.com/palantir/pkg/cobracli v1.0.1
 	github.com/palantir/pkg/metrics v1.2.0
 	github.com/palantir/pkg/retry v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -490,8 +490,8 @@ github.com/palantir/go-encrypted-config-value v1.1.0/go.mod h1:6c5zDN0XqZLxJiV3y
 github.com/palantir/go-metrics v1.1.0/go.mod h1:fRkuipBnsI4nD8Vd9UNcrUJvD8Y0wOJMSbicygcBrGs=
 github.com/palantir/go-metrics v1.1.1 h1:YL/UmptBjrC6iSCTVr7vfuIcjL0M359Da3/gBGNny10=
 github.com/palantir/go-metrics v1.1.1/go.mod h1:fRkuipBnsI4nD8Vd9UNcrUJvD8Y0wOJMSbicygcBrGs=
-github.com/palantir/k8s-spark-scheduler-lib v0.13.0 h1:z94VnWbNFcEI0K1PnCuWkeKJkKS2VL7sn5HpmaZNjrw=
-github.com/palantir/k8s-spark-scheduler-lib v0.13.0/go.mod h1:p05vQvL8nnxDyOwypa6DOWmr3PVxNgKnBuO/k3VXS/o=
+github.com/palantir/k8s-spark-scheduler-lib v0.15.0 h1:IQAvjcn9zokvLJ13D8Quc9qxCuFqUnXzf7MdkO/mFl0=
+github.com/palantir/k8s-spark-scheduler-lib v0.15.0/go.mod h1:p05vQvL8nnxDyOwypa6DOWmr3PVxNgKnBuO/k3VXS/o=
 github.com/palantir/pkg v1.0.1 h1:ZbGUcc14N7xcZSY9cehQoiHHTm/BAZO5RJdlsNEtSbk=
 github.com/palantir/pkg v1.0.1/go.mod h1:Eo6Jl0UXfT+65sLXJOcU9duu0WPvKsWFXCb0dE5VWZs=
 github.com/palantir/pkg/bytesbuffers v1.0.0/go.mod h1:JFWINutL8wfBpXOqastvJtuEXNEQhIVNnBVY0oeJFws=

--- a/vendor/github.com/palantir/k8s-spark-scheduler-lib/pkg/binpack/minimal_fragmentation.go
+++ b/vendor/github.com/palantir/k8s-spark-scheduler-lib/pkg/binpack/minimal_fragmentation.go
@@ -16,16 +16,14 @@ package binpack
 
 import (
 	"context"
-	"math"
 	"sort"
 
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/capacity"
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
-	"gopkg.in/inf.v0"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-// MinimalFragmentation is a SparkBinPackFunction that tries to put the driver pod on the first possible node with
-// enough capacity, and then tries to pack executors onto as few nodes as possible.
+// MinimalFragmentation is a SparkBinPackFunction that tries to minimize spark app fragmentation across the cluster.
+// see minimalFragmentation for more details.
 var MinimalFragmentation = SparkBinPackFunction(func(
 	ctx context.Context,
 	driverResources, executorResources *resources.Resources,
@@ -35,17 +33,29 @@ var MinimalFragmentation = SparkBinPackFunction(func(
 	return SparkBinPack(ctx, driverResources, executorResources, executorCount, driverNodePriorityOrder, executorNodePriorityOrder, nodesSchedulingMetadata, minimalFragmentation)
 })
 
-// minimalFragmentation attempts to pack executors onto as few nodes as possible, ideally a single one
+// minimalFragmentation attempts to pack executors onto as few nodes as possible, ideally a single one.
 // nodePriorityOrder is still used as a guideline, i.e. if an application can fit on multiple nodes, it will pick
-// the first eligible node according to nodePriorityOrder
+// the first eligible node according to nodePriorityOrder. additionally, minimalFragmentation will attempt to avoid
+// mostly empty nodes unless those are required for scheduling or they provide a perfect fit, see a couple examples below.
 //
-// for instance if nodePriorityOrder = [a, b, c, d, e]
-// and we can fit 1 executor on a, 1 executor on b, 3 executors on c, 5 executors on d, 5 executors on e
+// 'mostly' empty nodes are currently defined as the ones having capacity >= (executor count + max capacity) / 2
+//
+// for instance if nodePriorityOrder = [a, b, c, d, e, f]
+// and we can fit 1 executor on a, 1 executor on b, 3 executors on c, 5 executors on d, 5 executors on e, 17 executors on f
 // and executorCount = 11, then we will return:
 // [d, d, d, d, d, e, e, e, e, e, a], true
 //
 // if instead we have executorCount = 6, then we will return:
 // [d, d, d, d, d, a], true
+//
+// if instead we have executorCount = 15, then we will return:
+// [d, d, d, d, d, e, e, e, e, e, c, c, c, a, b], true
+//
+// if instead we have executorCount = 17, then we will return:
+// [f, f, ..., f], true
+//
+// if instead we have executorCount = 19, then we will return:
+// [f, f, ..., f, a, b], true
 func minimalFragmentation(
 	_ context.Context,
 	executorResources *resources.Resources,
@@ -53,40 +63,66 @@ func minimalFragmentation(
 	nodePriorityOrder []string,
 	nodeGroupSchedulingMetadata resources.NodeGroupSchedulingMetadata,
 	reservedResources resources.NodeGroupResources) ([]string, bool) {
-	executorNodes := make([]string, 0, executorCount)
 	if executorCount == 0 {
-		return executorNodes, true
+		return []string{}, true
 	}
 
-	nodeCapacities := getNodeCapacities(nodePriorityOrder, nodeGroupSchedulingMetadata, reservedResources, executorResources)
-	nodeCapacities = filterOutNodesWithoutCapacity(nodeCapacities)
-	sort.SliceStable(nodeCapacities, func(i, j int) bool {
-		return nodeCapacities[i].capacity < nodeCapacities[j].capacity
-	})
+	nodeCapacities := capacity.GetNodeCapacities(nodePriorityOrder, nodeGroupSchedulingMetadata, reservedResources, executorResources)
+	nodeCapacities = capacity.FilterOutNodesWithoutCapacity(nodeCapacities)
+	if len(nodeCapacities) == 0 {
+		return nil, false
+	}
 
-	// as long as we have nodes where we could schedule executors
-	for len(nodeCapacities) > 0 {
-		// pick the first node that could fit all the executors (if there's one)
-		position := sort.Search(len(nodeCapacities), func(i int) bool {
-			return nodeCapacities[i].capacity >= executorCount
+	sort.SliceStable(nodeCapacities, func(i, j int) bool {
+		return nodeCapacities[i].Capacity < nodeCapacities[j].Capacity
+	})
+	maxCapacity := nodeCapacities[len(nodeCapacities)-1].Capacity
+	if executorCount < maxCapacity {
+		targetCapacity := (executorCount + maxCapacity) / 2
+		firstNodeWithAtLeastTargetCapacity := sort.Search(len(nodeCapacities), func(i int) bool {
+			return nodeCapacities[i].Capacity >= targetCapacity
 		})
 
-		if position != len(nodeCapacities) {
+		// try scheduling on a subset of nodes that excludes the 'emptiest' nodes
+		if executorNodes, ok := internalMinimalFragmentation(executorCount, nodeCapacities[:firstNodeWithAtLeastTargetCapacity]); ok {
+			return executorNodes, ok
+		}
+	}
+
+	// fall back to using empty nodes
+	return internalMinimalFragmentation(executorCount, nodeCapacities)
+}
+
+func internalMinimalFragmentation(
+	executorCount int,
+	nodeCapacities []capacity.NodeAndExecutorCapacity) ([]string, bool) {
+	nodeCapacitiesCopy := make([]capacity.NodeAndExecutorCapacity, 0, len(nodeCapacities))
+	nodeCapacitiesCopy = append(nodeCapacitiesCopy, nodeCapacities...)
+	executorNodes := make([]string, 0, executorCount)
+
+	// as long as we have nodes where we could schedule executors
+	for len(nodeCapacitiesCopy) > 0 {
+		// pick the first node that could fit all the executors (if there's one)
+		position := sort.Search(len(nodeCapacitiesCopy), func(i int) bool {
+			return nodeCapacitiesCopy[i].Capacity >= executorCount
+		})
+
+		if position != len(nodeCapacitiesCopy) {
 			// we found a node that has the required capacity, schedule everything there and we're done
-			return append(executorNodes, repeat(nodeCapacities[position].nodeName, executorCount)...), true
+			return append(executorNodes, repeat(nodeCapacitiesCopy[position].NodeName, executorCount)...), true
 		}
 
 		// we will need multiple nodes for scheduling, thus we'll try to schedule executors on nodes with the most capacity
-		maxCapacity := nodeCapacities[len(nodeCapacities)-1].capacity
-		firstNodeWithMaxCapacityIdx := sort.Search(len(nodeCapacities), func(i int) bool {
-			return nodeCapacities[i].capacity >= maxCapacity
+		maxCapacity := nodeCapacitiesCopy[len(nodeCapacitiesCopy)-1].Capacity
+		firstNodeWithMaxCapacityIdx := sort.Search(len(nodeCapacitiesCopy), func(i int) bool {
+			return nodeCapacitiesCopy[i].Capacity >= maxCapacity
 		})
 
 		// the loop will exit because maxCapacity is always > 0
 		currentPos := firstNodeWithMaxCapacityIdx
-		for ; executorCount >= maxCapacity && currentPos < len(nodeCapacities); currentPos++ {
+		for ; executorCount >= maxCapacity && currentPos < len(nodeCapacitiesCopy); currentPos++ {
 			// we can skip the check on firstNodeWithMaxCapacityIdx since we know at least one node will be found
-			executorNodes = append(executorNodes, repeat(nodeCapacities[currentPos].nodeName, maxCapacity)...)
+			executorNodes = append(executorNodes, repeat(nodeCapacitiesCopy[currentPos].NodeName, maxCapacity)...)
 			executorCount -= maxCapacity
 		}
 
@@ -94,106 +130,10 @@ func minimalFragmentation(
 			return executorNodes, true
 		}
 
-		nodeCapacities = append(nodeCapacities[:firstNodeWithMaxCapacityIdx], nodeCapacities[currentPos:]...)
+		nodeCapacitiesCopy = append(nodeCapacitiesCopy[:firstNodeWithMaxCapacityIdx], nodeCapacitiesCopy[currentPos:]...)
 	}
 
 	return nil, false
-}
-
-type nodeAndExecutorCapacity struct {
-	nodeName string
-	capacity int
-}
-
-// getCapacityAgainstSingleDimension computes how many times we can fit the required quantity within (available-reserved)
-// e.g. if required = 4, available = 14, reserved = 1, we can fit 3 executors (3 * required <= available - reserved)
-//
-// This function is only useful to compare one dimension at a time, e.g. CPU or Memory, use getNodeCapacity to account
-// for all dimensions
-func getCapacityAgainstSingleDimension(available, reserved, required resource.Quantity) int {
-	if reserved.Cmp(available) == 1 {
-		// ideally this shouldn't happen (reserved > available), but should this happen, let's be resilient
-		return 0
-	}
-
-	if required.IsZero() {
-		// if we don't require any resources for this dimension, then we can fit an infinite number of executors
-		return math.MaxInt
-	}
-
-	// this basically computes: floor((available - reserved) / required)
-	return int(new(inf.Dec).QuoRound(
-		new(inf.Dec).Sub(available.AsDec(), reserved.AsDec()),
-		required.AsDec(),
-		0,
-		inf.RoundFloor,
-	).UnscaledBig().Int64())
-}
-
-func getNodeCapacity(available, reserved, singleExecutor *resources.Resources) int {
-	capacityConsideringCPUOnly := getCapacityAgainstSingleDimension(
-		available.CPU,
-		reserved.CPU,
-		singleExecutor.CPU,
-	)
-	capacityConsideringMemoryOnly := getCapacityAgainstSingleDimension(
-		available.Memory,
-		reserved.Memory,
-		singleExecutor.Memory,
-	)
-	capacityConsideringNvidiaGPUOnly := getCapacityAgainstSingleDimension(
-		available.NvidiaGPU,
-		reserved.NvidiaGPU,
-		singleExecutor.NvidiaGPU,
-	)
-
-	return min(capacityConsideringCPUOnly, capacityConsideringMemoryOnly, capacityConsideringNvidiaGPUOnly)
-}
-
-// getNodeCapacities' return value is ordered according to nodePriorityOrder
-func getNodeCapacities(
-	nodePriorityOrder []string,
-	nodeGroupSchedulingMetadata resources.NodeGroupSchedulingMetadata,
-	reservedResources resources.NodeGroupResources,
-	singleExecutor *resources.Resources,
-) []nodeAndExecutorCapacity {
-	capacities := make([]nodeAndExecutorCapacity, 0, len(nodePriorityOrder))
-
-	for _, nodeName := range nodePriorityOrder {
-		if nodeSchedulingMetadata, ok := nodeGroupSchedulingMetadata[nodeName]; ok {
-			reserved := resources.Zero()
-
-			if alreadyReserved, ok := reservedResources[nodeName]; ok {
-				reserved = alreadyReserved
-			}
-
-			capacities = append(capacities, nodeAndExecutorCapacity{
-				nodeName,
-				getNodeCapacity(nodeSchedulingMetadata.AvailableResources, reserved, singleExecutor),
-			})
-		}
-	}
-
-	return capacities
-}
-
-func filterOutNodesWithoutCapacity(capacities []nodeAndExecutorCapacity) []nodeAndExecutorCapacity {
-	filteredCapacities := make([]nodeAndExecutorCapacity, 0, len(capacities))
-	for _, nodeWithCapacity := range capacities {
-		if nodeWithCapacity.capacity > 0 {
-			filteredCapacities = append(filteredCapacities, nodeWithCapacity)
-		}
-	}
-	return filteredCapacities
-}
-
-func min(a, b, c int) int {
-	if a <= b && a <= c {
-		return a
-	} else if b <= c {
-		return b
-	}
-	return c
 }
 
 func repeat(str string, n int) []string {

--- a/vendor/github.com/palantir/k8s-spark-scheduler-lib/pkg/capacity/capacity.go
+++ b/vendor/github.com/palantir/k8s-spark-scheduler-lib/pkg/capacity/capacity.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package capacity
+
+import (
+	"math"
+
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
+	"gopkg.in/inf.v0"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// NodeAndExecutorCapacity is a pair of node name and capacity (how many executors can it fit)
+type NodeAndExecutorCapacity struct {
+	NodeName string
+	Capacity int
+}
+
+// getCapacityAgainstSingleDimension computes how many times we can fit the required quantity within (available-reserved)
+// e.g. if required = 4, available = 14, reserved = 1, we can fit 3 executors (3 * required <= available - reserved)
+//
+// This function is only useful to compare one dimension at a time, e.g. CPU or Memory, use GetNodeCapacity to account
+// for all dimensions
+func getCapacityAgainstSingleDimension(available, reserved, required resource.Quantity) int {
+	if reserved.Cmp(available) == 1 {
+		// ideally this shouldn't happen (reserved > available), but should this happen, let's be resilient
+		return 0
+	}
+
+	if required.IsZero() {
+		// if we don't require any resources for this dimension, then we can fit an infinite number of executors
+		return math.MaxInt
+	}
+
+	// this basically computes: floor((available - reserved) / required)
+	return int(new(inf.Dec).QuoRound(
+		new(inf.Dec).Sub(available.AsDec(), reserved.AsDec()),
+		required.AsDec(),
+		0,
+		inf.RoundFloor,
+	).UnscaledBig().Int64())
+}
+
+// GetNodeCapacity returns how many singleExecutor can fit within available - reserved
+func GetNodeCapacity(available, reserved, singleExecutor *resources.Resources) int {
+	capacityConsideringCPUOnly := getCapacityAgainstSingleDimension(
+		available.CPU,
+		reserved.CPU,
+		singleExecutor.CPU,
+	)
+	capacityConsideringMemoryOnly := getCapacityAgainstSingleDimension(
+		available.Memory,
+		reserved.Memory,
+		singleExecutor.Memory,
+	)
+	capacityConsideringNvidiaGPUOnly := getCapacityAgainstSingleDimension(
+		available.NvidiaGPU,
+		reserved.NvidiaGPU,
+		singleExecutor.NvidiaGPU,
+	)
+
+	return min(capacityConsideringCPUOnly, capacityConsideringMemoryOnly, capacityConsideringNvidiaGPUOnly)
+}
+
+// GetNodeCapacities return value is ordered according to nodePriorityOrder
+func GetNodeCapacities(
+	nodePriorityOrder []string,
+	nodeGroupSchedulingMetadata resources.NodeGroupSchedulingMetadata,
+	reservedResources resources.NodeGroupResources,
+	singleExecutor *resources.Resources,
+) []NodeAndExecutorCapacity {
+	capacities := make([]NodeAndExecutorCapacity, 0, len(nodePriorityOrder))
+
+	for _, nodeName := range nodePriorityOrder {
+		if nodeSchedulingMetadata, ok := nodeGroupSchedulingMetadata[nodeName]; ok {
+			reserved := resources.Zero()
+
+			if alreadyReserved, ok := reservedResources[nodeName]; ok {
+				reserved = alreadyReserved
+			}
+
+			capacities = append(capacities, NodeAndExecutorCapacity{
+				nodeName,
+				GetNodeCapacity(nodeSchedulingMetadata.AvailableResources, reserved, singleExecutor),
+			})
+		}
+	}
+
+	return capacities
+}
+
+// FilterOutNodesWithoutCapacity returns a slice of nodes with non-zero capacity
+func FilterOutNodesWithoutCapacity(capacities []NodeAndExecutorCapacity) []NodeAndExecutorCapacity {
+	filteredCapacities := make([]NodeAndExecutorCapacity, 0, len(capacities))
+	for _, nodeWithCapacity := range capacities {
+		if nodeWithCapacity.Capacity > 0 {
+			filteredCapacities = append(filteredCapacities, nodeWithCapacity)
+		}
+	}
+	return filteredCapacities
+}
+
+func min(a, b, c int) int {
+	if a <= b && a <= c {
+		return a
+	} else if b <= c {
+		return b
+	}
+	return c
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -105,7 +105,7 @@ github.com/palantir/go-encrypted-config-value/encryption
 # github.com/palantir/go-metrics v1.1.1
 ## explicit; go 1.13
 github.com/palantir/go-metrics
-# github.com/palantir/k8s-spark-scheduler-lib v0.13.0
+# github.com/palantir/k8s-spark-scheduler-lib v0.15.0
 ## explicit; go 1.19
 github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/scaler/v1alpha1
 github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/scaler/v1alpha2
@@ -113,6 +113,7 @@ github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler
 github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta1
 github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/sparkscheduler/v1beta2
 github.com/palantir/k8s-spark-scheduler-lib/pkg/binpack
+github.com/palantir/k8s-spark-scheduler-lib/pkg/capacity
 github.com/palantir/k8s-spark-scheduler-lib/pkg/client/clientset/versioned
 github.com/palantir/k8s-spark-scheduler-lib/pkg/client/clientset/versioned/fake
 github.com/palantir/k8s-spark-scheduler-lib/pkg/client/clientset/versioned/scheme


### PR DESCRIPTION
0.15.0 includes https://github.com/palantir/k8s-spark-scheduler-lib/pull/104

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Bump spark-scheduler-lib to 0.15.0
==COMMIT_MSG==
