### PR TITLE
Report # executors / # nodes used to schedule this application

### DIFF
--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -351,7 +351,7 @@ func (s *SparkSchedulerExtender) selectDriverNode(
 
 	s.removeDemandIfExists(ctx, driver)
 	metrics.ReportInitialDriverExecutorCollocationMetric(ctx, instanceGroup, packingResult.DriverNode, packingResult.ExecutorNodes)
-	metrics.ReportInitialExecutorsPerNodeMetric(ctx, instanceGroup, packingResult.ExecutorNodes)
+	metrics.ReportInitialNodeCountMetrics(ctx, instanceGroup, packingResult.ExecutorNodes)
 	metrics.ReportCrossZoneMetric(ctx, instanceGroup, packingResult.DriverNode, packingResult.ExecutorNodes, availableNodes)
 
 	_, err = s.resourceReservationManager.CreateReservations(

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -351,6 +351,7 @@ func (s *SparkSchedulerExtender) selectDriverNode(
 
 	s.removeDemandIfExists(ctx, driver)
 	metrics.ReportInitialDriverExecutorCollocationMetric(ctx, instanceGroup, packingResult.DriverNode, packingResult.ExecutorNodes)
+	metrics.ReportInitialExecutorsPerNodeMetric(ctx, instanceGroup, packingResult.ExecutorNodes)
 	metrics.ReportCrossZoneMetric(ctx, instanceGroup, packingResult.DriverNode, packingResult.ExecutorNodes, availableNodes)
 
 	_, err = s.resourceReservationManager.CreateReservations(

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -58,6 +58,7 @@ const (
 	schedulingWastePerInstanceGroup           = "foundry.spark.scheduler.scheduling.wasteperinstancegroup"
 	initialDriverExecutorCollocation          = "foundry.spark.scheduler.scheduling.initialdriverexecutorcollocation"
 	initialExecutorsPerNode                   = "foundry.spark.scheduler.scheduling.initialexecutorspernode"
+	initialNodeCount                          = "foundry.spark.scheduler.scheduling.initialnodecount"
 )
 
 const (
@@ -233,14 +234,18 @@ func ReportInitialDriverExecutorCollocationMetric(ctx context.Context, instanceG
 	metrics.FromContext(ctx).Counter(initialDriverExecutorCollocation, instanceGroupTag, collocationTypeTag).Inc(1)
 }
 
-// ReportInitialExecutorsPerNodeMetric reports a metric about how many executors are hosted per node for a given spark
-// application. This ignores executor-less applications.
+// ReportInitialNodeCountMetrics reports two metrics used to reason about how fragmented a Spark app is.
+//
+// The first metric measures how many executors are hosted per node for a given spark application. This ignores
+// executor-less applications.
 //
 // For instance for an application with 6 executors being scheduled on a single node the metric would be 6,
 // if this application was instead scheduled on 2 nodes, then the metric would be 3.
 //
-// This metric is only reported during the initial scheduling of the Spark application.
-func ReportInitialExecutorsPerNodeMetric(ctx context.Context, instanceGroup string, executorNodeNames []string) {
+// The second metric simply tracks how many unique nodes are being used to schedule all the executors.
+//
+// Those metrics are only reported during the initial scheduling of the Spark application.
+func ReportInitialNodeCountMetrics(ctx context.Context, instanceGroup string, executorNodeNames []string) {
 	executorCount := len(executorNodeNames)
 	if executorCount == 0 {
 		return
@@ -251,6 +256,7 @@ func ReportInitialExecutorsPerNodeMetric(ctx context.Context, instanceGroup stri
 	ratio := executorCount / len(executorNodeNamesSet)
 
 	metrics.FromContext(ctx).Histogram(initialExecutorsPerNode, instanceGroupTag).Update(int64(ratio))
+	metrics.FromContext(ctx).Histogram(initialNodeCount, instanceGroupTag).Update(int64(len(executorNodeNamesSet)))
 }
 
 func toExecutorNodeNamesSet(executorNodeNames []string) map[string]bool {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -56,7 +56,8 @@ const (
 	podInformerDelay                          = "foundry.spark.scheduler.informer.delay"
 	schedulingWaste                           = "foundry.spark.scheduler.scheduling.waste"
 	schedulingWastePerInstanceGroup           = "foundry.spark.scheduler.scheduling.wasteperinstancegroup"
-	initialDriverExecutorCollocation          = "foundry.spark.scheduler.scheduling.driverexecutorinitialcollocation"
+	initialDriverExecutorCollocation          = "foundry.spark.scheduler.scheduling.initialdriverexecutorcollocation"
+	initialExecutorsPerNode                   = "foundry.spark.scheduler.scheduling.initialexecutorspernode"
 )
 
 const (
@@ -214,10 +215,7 @@ func (s *ScheduleTimer) Mark(ctx context.Context, role, outcome string) {
 // This metric is only reported during the initial scheduling of the Spark application.
 func ReportInitialDriverExecutorCollocationMetric(ctx context.Context, instanceGroup string, driverNodeName string, executorNodeNames []string) {
 	instanceGroupTag := InstanceGroupTag(ctx, instanceGroup)
-	executorNodeNamesSet := make(map[string]bool)
-	for _, node := range executorNodeNames {
-		executorNodeNamesSet[node] = true
-	}
+	executorNodeNamesSet := toExecutorNodeNamesSet(executorNodeNames)
 
 	if !executorNodeNamesSet[driverNodeName] {
 		collocationTypeTag := CollocationTypeTag(ctx, "no-collocation")
@@ -233,6 +231,34 @@ func ReportInitialDriverExecutorCollocationMetric(ctx context.Context, instanceG
 
 	collocationTypeTag := CollocationTypeTag(ctx, "driver-collocated-with-some-executors")
 	metrics.FromContext(ctx).Counter(initialDriverExecutorCollocation, instanceGroupTag, collocationTypeTag).Inc(1)
+}
+
+// ReportInitialExecutorsPerNodeMetric reports a metric about how many executors are hosted per node for a given spark
+// application. This ignores executor-less applications.
+//
+// For instance for an application with 6 executors being scheduled on a single node the metric would be 6,
+// if this application was instead scheduled on 2 nodes, then the metric would be 3.
+//
+// This metric is only reported during the initial scheduling of the Spark application.
+func ReportInitialExecutorsPerNodeMetric(ctx context.Context, instanceGroup string, executorNodeNames []string) {
+	executorCount := len(executorNodeNames)
+	if executorCount == 0 {
+		return
+	}
+
+	instanceGroupTag := InstanceGroupTag(ctx, instanceGroup)
+	executorNodeNamesSet := toExecutorNodeNamesSet(executorNodeNames)
+	ratio := executorCount / len(executorNodeNamesSet)
+
+	metrics.FromContext(ctx).Histogram(initialExecutorsPerNode, instanceGroupTag).Update(int64(ratio))
+}
+
+func toExecutorNodeNamesSet(executorNodeNames []string) map[string]bool {
+	executorNodeNamesSet := make(map[string]bool)
+	for _, node := range executorNodeNames {
+		executorNodeNamesSet[node] = true
+	}
+	return executorNodeNamesSet
 }
 
 // ReportCrossZoneMetric reports metric about cross AZ traffic between pods of a spark application


### PR DESCRIPTION
## Before this PR

We don't have a good way to quantify fragmentation. With this new metric we should be able to observe whether https://github.com/palantir/k8s-spark-scheduler-lib/pull/100 actually reduces fragmentation (this metric should go up in this case).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Report # executors / # nodes used to schedule this application
==COMMIT_MSG==

## Possible downsides?

`Histogram` works with `int64`,not `float64`, either we get something a little imprecise e.g. 5 executors on 3 nodes = 5 / 3 = 1, or we need to scale the metric 100 * 5 / 3 = 166, but then this is a bit confusing as the metric doesn't report the true ratio anymore. Given that we mostly care about fragmentation of larger applications where this metric should ideally be well above 1, I went with the former approach.