### PR TITLE
Report how much resources are currently reserved but unbound

### DIFF
--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -177,6 +177,7 @@ func (s *SparkSchedulerExtender) Predicate(ctx context.Context, args schedulerap
 	}
 
 	logger.Info("scheduling pod to node", svc1log.SafeParam("nodeName", nodeName))
+	metrics.ReportTotalUnboundReservedResourcesMetric(ctx, s.resourceReservationManager)
 	return &schedulerapi.ExtenderFilterResult{NodeNames: &[]string{nodeName}}
 }
 

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -177,7 +177,7 @@ func (s *SparkSchedulerExtender) Predicate(ctx context.Context, args schedulerap
 	}
 
 	logger.Info("scheduling pod to node", svc1log.SafeParam("nodeName", nodeName))
-	metrics.ReportTotalUnboundReservedResourcesMetric(ctx, s.resourceReservationManager)
+	metrics.ReportTotalUnboundReservedResourcesMetric(ctx, s.resourceReservationManager.GetTotalUnboundReservedResources())
 	return &schedulerapi.ExtenderFilterResult{NodeNames: &[]string{nodeName}}
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -16,11 +16,11 @@ package metrics
 
 import (
 	"context"
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"net/url"
 	"strconv"
 	"time"
 
-	"github.com/palantir/k8s-spark-scheduler/internal/extender"
 	"github.com/palantir/pkg/metrics"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	v1 "k8s.io/api/core/v1"
@@ -217,8 +217,7 @@ func (s *ScheduleTimer) Mark(ctx context.Context, role, outcome string) {
 }
 
 // ReportTotalUnboundReservedResourcesMetric reports metrics measuring how much resources are reserved yet unbound.
-func ReportTotalUnboundReservedResourcesMetric(ctx context.Context, rrm *extender.ResourceReservationManager) {
-	resources := rrm.GetTotalUnboundReservedResources()
+func ReportTotalUnboundReservedResourcesMetric(ctx context.Context, resources *resources.Resources) {
 	metrics.FromContext(ctx).GaugeFloat64(unboundCPUReservations).Update(resources.CPU.AsApproximateFloat64())
 	metrics.FromContext(ctx).GaugeFloat64(unboundMemoryReservations).Update(resources.Memory.AsApproximateFloat64())
 	metrics.FromContext(ctx).GaugeFloat64(unboundNvidiaGPUReservations).Update(resources.NvidiaGPU.AsApproximateFloat64())

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -16,11 +16,11 @@ package metrics
 
 import (
 	"context"
-	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"net/url"
 	"strconv"
 	"time"
 
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"github.com/palantir/pkg/metrics"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	v1 "k8s.io/api/core/v1"


### PR DESCRIPTION
## Before this PR

It's hard to assess how much waste is due to resources being reserved yet unbound (we reserve when scheduling the executor, but those reservations remain unbound until the driver actually requests executors).

## After this PR

==COMMIT_MSG==
Report how much resources are currently reserved but unbound
==COMMIT_MSG==
