### PR TITLE
improvement: Move the demand processing behind a single interface that can be shared

### DIFF
--- a/internal/binpacker/binpack.go
+++ b/internal/binpacker/binpack.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package extender
+package binpacker
 
 import (
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/binpack"

--- a/internal/demands/demand.go
+++ b/internal/demands/demand.go
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package extender
+package demands
 
 import (
 	"context"
 	"encoding/json"
+	"github.com/palantir/k8s-spark-scheduler/internal/binpacker"
+	"github.com/palantir/k8s-spark-scheduler/internal/types"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	demandapi "github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/scaler/v1alpha2"
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
@@ -43,24 +46,43 @@ var (
 	}
 )
 
+type Manager interface {
+	DeleteDemandIfExists(ctx context.Context, pod *v1.Pod, source string)
+	CreateDemandForApplicationInAnyZone(ctx context.Context, driverPod *v1.Pod, applicationResources *types.SparkApplicationResources)
+	CreateDemandForExecutorInAnyZone(ctx context.Context, executorPod *v1.Pod, executorResources *resources.Resources)
+	CreateDemandForExecutorInSpecificZone(ctx context.Context, executorPod *v1.Pod, executorResources *resources.Resources, zone *demandapi.Zone)
+}
+
+type defaultManager struct {
+	coreClient         corev1.CoreV1Interface
+	demands            *cache.SafeDemandCache
+	instanceGroupLabel string
+	binpacker          *binpacker.Binpacker
+}
+
+func NewDefaultManager() Manager {
+	panic("NewDefaultManager")
+
+}
+
 // TODO: should patch instead of put to avoid conflicts
-func (s *SparkSchedulerExtender) updatePodStatus(ctx context.Context, pod *v1.Pod, _ *v1.PodCondition) {
+func (d *defaultManager) updatePodStatus(ctx context.Context, pod *v1.Pod, _ *v1.PodCondition) {
 	if !podutil.UpdatePodCondition(&pod.Status, demandCreatedCondition) {
 		svc1log.FromContext(ctx).Info("pod condition for demand creation already exist")
 		return
 	}
-	_, err := s.coreClient.Pods(pod.Namespace).UpdateStatus(ctx, pod, metav1.UpdateOptions{})
+	_, err := d.coreClient.Pods(pod.Namespace).UpdateStatus(ctx, pod, metav1.UpdateOptions{})
 	if err != nil {
 		svc1log.FromContext(ctx).Warn("pod condition update failed", svc1log.SafeParam("reason", err.Error()))
 	}
 }
 
-func (s *SparkSchedulerExtender) createDemandForExecutorInAnyZone(ctx context.Context, executorPod *v1.Pod, executorResources *resources.Resources) {
-	s.createDemandForExecutorInSpecificZone(ctx, executorPod, executorResources, nil)
+func (d *defaultManager) CreateDemandForExecutorInAnyZone(ctx context.Context, executorPod *v1.Pod, executorResources *resources.Resources) {
+	d.CreateDemandForExecutorInSpecificZone(ctx, executorPod, executorResources, nil)
 }
 
-func (s *SparkSchedulerExtender) createDemandForExecutorInSpecificZone(ctx context.Context, executorPod *v1.Pod, executorResources *resources.Resources, zone *demandapi.Zone) {
-	if !s.demands.CRDExists() {
+func (d *defaultManager) CreateDemandForExecutorInSpecificZone(ctx context.Context, executorPod *v1.Pod, executorResources *resources.Resources, zone *demandapi.Zone) {
+	if !d.demands.CRDExists() {
 		return
 	}
 	units := []demandapi.DemandUnit{
@@ -76,46 +98,46 @@ func (s *SparkSchedulerExtender) createDemandForExecutorInSpecificZone(ctx conte
 			},
 		},
 	}
-	s.createDemand(ctx, executorPod, units, zone)
+	d.createDemand(ctx, executorPod, units, zone)
 }
 
-func (s *SparkSchedulerExtender) createDemandForApplicationInAnyZone(ctx context.Context, driverPod *v1.Pod, applicationResources *sparkApplicationResources) {
-	if !s.demands.CRDExists() {
+func (d *defaultManager) CreateDemandForApplicationInAnyZone(ctx context.Context, driverPod *v1.Pod, applicationResources *types.SparkApplicationResources) {
+	if !d.demands.CRDExists() {
 		return
 	}
-	s.createDemand(ctx, driverPod, demandResourcesForApplication(driverPod, applicationResources), nil)
+	d.createDemand(ctx, driverPod, demandResourcesForApplication(driverPod, applicationResources), nil)
 }
 
-func (s *SparkSchedulerExtender) createDemand(ctx context.Context, pod *v1.Pod, demandUnits []demandapi.DemandUnit, zone *demandapi.Zone) {
-	instanceGroup, ok := internal.FindInstanceGroupFromPodSpec(pod.Spec, s.instanceGroupLabel)
+func (d *defaultManager) createDemand(ctx context.Context, pod *v1.Pod, demandUnits []demandapi.DemandUnit, zone *demandapi.Zone) {
+	instanceGroup, ok := internal.FindInstanceGroupFromPodSpec(pod.Spec, d.instanceGroupLabel)
 	if !ok {
 		svc1log.FromContext(ctx).Error("No instanceGroup label exists. Cannot map to InstanceGroup. Skipping demand object",
-			svc1log.SafeParam("expectedLabel", s.instanceGroupLabel))
+			svc1log.SafeParam("expectedLabel", d.instanceGroupLabel))
 		return
 	}
 
-	newDemand, err := s.newDemand(pod, instanceGroup, demandUnits, zone)
+	newDemand, err := d.newDemand(pod, instanceGroup, demandUnits, zone)
 	if err != nil {
 		svc1log.FromContext(ctx).Error("failed to construct demand object", svc1log.Stacktrace(err))
 		return
 	}
-	err = s.doCreateDemand(ctx, newDemand)
+	err = d.doCreateDemand(ctx, newDemand)
 	if err != nil {
 		svc1log.FromContext(ctx).Error("failed to create demand", svc1log.Stacktrace(err))
 		return
 	}
-	go s.updatePodStatus(ctx, pod, demandCreatedCondition)
+	go d.updatePodStatus(ctx, pod, demandCreatedCondition)
 }
 
-func (s *SparkSchedulerExtender) doCreateDemand(ctx context.Context, newDemand *demandapi.Demand) error {
+func (d *defaultManager) doCreateDemand(ctx context.Context, newDemand *demandapi.Demand) error {
 	demandObjectBytes, err := json.Marshal(newDemand)
 	if err != nil {
 		return werror.Wrap(err, "failed to marshal demand object")
 	}
 	svc1log.FromContext(ctx).Info("Creating demand object", svc1log.SafeParams(internal.DemandSafeParamsFromObj(newDemand)), svc1log.SafeParam("demandObjectBytes", string(demandObjectBytes)))
-	err = s.demands.Create(newDemand)
+	err = d.demands.Create(newDemand)
 	if err != nil {
-		_, ok := s.demands.Get(newDemand.Namespace, newDemand.Name)
+		_, ok := d.demands.Get(newDemand.Namespace, newDemand.Name)
 		if ok {
 			svc1log.FromContext(ctx).Info("demand object already exists for pod so no action will be taken")
 			return nil
@@ -125,25 +147,25 @@ func (s *SparkSchedulerExtender) doCreateDemand(ctx context.Context, newDemand *
 	return err
 }
 
-func (s *SparkSchedulerExtender) removeDemandIfExists(ctx context.Context, pod *v1.Pod) {
-	DeleteDemandIfExists(ctx, s.demands, pod, "SparkSchedulerExtender")
+func (d *defaultManager) removeDemandIfExists(ctx context.Context, pod *v1.Pod) {
+	d.DeleteDemandIfExists(ctx, pod, "SparkSchedulerExtender")
 }
 
 // DeleteDemandIfExists removes a demand object if it exists, and emits an event tagged by the source of the deletion
-func DeleteDemandIfExists(ctx context.Context, cache *cache.SafeDemandCache, pod *v1.Pod, source string) {
-	if !cache.CRDExists() {
+func (d *defaultManager) DeleteDemandIfExists(ctx context.Context, pod *v1.Pod, source string) {
+	if !d.demands.CRDExists() {
 		return
 	}
 	demandName := utils.DemandName(pod)
-	if demand, ok := cache.Get(pod.Namespace, demandName); ok {
+	if demand, ok := d.demands.Get(pod.Namespace, demandName); ok {
 		// there is no harm in the demand being deleted elsewhere in between the two calls.
-		cache.Delete(pod.Namespace, demandName)
+		d.demands.Delete(pod.Namespace, demandName)
 		svc1log.FromContext(ctx).Info("Removed demand object for pod", svc1log.SafeParams(internal.DemandSafeParams(demandName, pod.Namespace)))
 		events.EmitDemandDeleted(ctx, demand, source)
 	}
 }
 
-func (s *SparkSchedulerExtender) newDemand(pod *v1.Pod, instanceGroup string, units []demandapi.DemandUnit, zone *demandapi.Zone) (*demandapi.Demand, error) {
+func (d *defaultManager) newDemand(pod *v1.Pod, instanceGroup string, units []demandapi.DemandUnit, zone *demandapi.Zone) (*demandapi.Demand, error) {
 	appID, ok := pod.Labels[common.SparkAppIDLabel]
 	if !ok {
 		return nil, werror.Error("pod did not contain expected label for AppID", werror.SafeParam("expectedLabel", common.SparkAppIDLabel))
@@ -157,26 +179,26 @@ func (s *SparkSchedulerExtender) newDemand(pod *v1.Pod, instanceGroup string, un
 				common.SparkAppIDLabel: appID,
 			},
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(pod, podGroupVersionKind),
+				*metav1.NewControllerRef(pod, types.PodGroupVersionKind),
 			},
 		},
 		Spec: demandapi.DemandSpec{
 			InstanceGroup:               instanceGroup,
 			Units:                       units,
-			EnforceSingleZoneScheduling: s.binpacker.IsSingleAz,
+			EnforceSingleZoneScheduling: d.binpacker.IsSingleAz,
 			Zone:                        zone,
 		},
 	}, nil
 }
 
-func demandResourcesForApplication(driverPod *v1.Pod, applicationResources *sparkApplicationResources) []demandapi.DemandUnit {
+func demandResourcesForApplication(driverPod *v1.Pod, applicationResources *types.SparkApplicationResources) []demandapi.DemandUnit {
 	demandUnits := []demandapi.DemandUnit{
 		{
 			Count: 1,
 			Resources: demandapi.ResourceList{
-				demandapi.ResourceCPU:       applicationResources.driverResources.CPU,
-				demandapi.ResourceMemory:    applicationResources.driverResources.Memory,
-				demandapi.ResourceNvidiaGPU: applicationResources.driverResources.NvidiaGPU,
+				demandapi.ResourceCPU:       applicationResources.DriverResources.CPU,
+				demandapi.ResourceMemory:    applicationResources.DriverResources.Memory,
+				demandapi.ResourceNvidiaGPU: applicationResources.DriverResources.NvidiaGPU,
 			},
 			// By specifying the pod driver pod here, we don't duplicate the resources of the pod with the created demand
 			PodNamesByNamespace: map[string][]string{
@@ -184,13 +206,13 @@ func demandResourcesForApplication(driverPod *v1.Pod, applicationResources *spar
 			},
 		},
 	}
-	if applicationResources.minExecutorCount > 0 {
+	if applicationResources.MinExecutorCount > 0 {
 		demandUnits = append(demandUnits, demandapi.DemandUnit{
-			Count: applicationResources.minExecutorCount,
+			Count: applicationResources.MinExecutorCount,
 			Resources: demandapi.ResourceList{
-				demandapi.ResourceCPU:       applicationResources.executorResources.CPU,
-				demandapi.ResourceMemory:    applicationResources.executorResources.Memory,
-				demandapi.ResourceNvidiaGPU: applicationResources.executorResources.NvidiaGPU,
+				demandapi.ResourceCPU:       applicationResources.ExecutorResources.CPU,
+				demandapi.ResourceMemory:    applicationResources.ExecutorResources.Memory,
+				demandapi.ResourceNvidiaGPU: applicationResources.ExecutorResources.NvidiaGPU,
 			},
 		})
 	}

--- a/internal/demands/demand.go
+++ b/internal/demands/demand.go
@@ -46,6 +46,7 @@ var (
 	}
 )
 
+// Manager holds the types of demand operations that are available
 type Manager interface {
 	DeleteDemandIfExists(ctx context.Context, pod *v1.Pod, source string)
 	CreateDemandForApplicationInAnyZone(ctx context.Context, driverPod *v1.Pod, applicationResources *types.SparkApplicationResources)

--- a/internal/demands/demand.go
+++ b/internal/demands/demand.go
@@ -17,21 +17,21 @@ package demands
 import (
 	"context"
 	"encoding/json"
-	"github.com/palantir/k8s-spark-scheduler/internal/binpacker"
-	"github.com/palantir/k8s-spark-scheduler/internal/types"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	demandapi "github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/scaler/v1alpha2"
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"github.com/palantir/k8s-spark-scheduler/internal"
+	"github.com/palantir/k8s-spark-scheduler/internal/binpacker"
 	"github.com/palantir/k8s-spark-scheduler/internal/cache"
 	"github.com/palantir/k8s-spark-scheduler/internal/common"
 	"github.com/palantir/k8s-spark-scheduler/internal/common/utils"
 	"github.com/palantir/k8s-spark-scheduler/internal/events"
+	"github.com/palantir/k8s-spark-scheduler/internal/types"
 	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 )
 
@@ -60,6 +60,7 @@ type defaultManager struct {
 	instanceGroupLabel string
 }
 
+// NewDefaultManager creates the default implementation of the Manager
 func NewDefaultManager(
 	coreClient corev1.CoreV1Interface,
 	demands *cache.SafeDemandCache,

--- a/internal/demands/demand.go
+++ b/internal/demands/demand.go
@@ -56,13 +56,21 @@ type Manager interface {
 type defaultManager struct {
 	coreClient         corev1.CoreV1Interface
 	demands            *cache.SafeDemandCache
-	instanceGroupLabel string
 	binpacker          *binpacker.Binpacker
+	instanceGroupLabel string
 }
 
-func NewDefaultManager() Manager {
-	panic("NewDefaultManager")
-
+func NewDefaultManager(
+	coreClient corev1.CoreV1Interface,
+	demands *cache.SafeDemandCache,
+	binpacker *binpacker.Binpacker,
+	instanceGroupLabel string) Manager {
+	return &defaultManager{
+		coreClient:         coreClient,
+		demands:            demands,
+		binpacker:          binpacker,
+		instanceGroupLabel: instanceGroupLabel,
+	}
 }
 
 // TODO: should patch instead of put to avoid conflicts

--- a/internal/demands/demand_test.go
+++ b/internal/demands/demand_test.go
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package extender
+package demands
 
 import (
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
+	"github.com/palantir/k8s-spark-scheduler/internal/types"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"reflect"
 	"testing"
 
@@ -23,13 +26,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var testResource = createResources(1, 2432*1024*1024, 1)
+var testResource = &resources.Resources{
+	CPU:       *resource.NewQuantity(1, resource.DecimalSI),
+	Memory:    *resource.NewQuantity(2432*1024*1024, resource.BinarySI),
+	NvidiaGPU: *resource.NewQuantity(1, resource.DecimalSI),
+}
 
-var testResources = &sparkApplicationResources{
-	driverResources:   testResource,
-	executorResources: testResource,
-	minExecutorCount:  0,
-	maxExecutorCount:  0,
+var testResources = &types.SparkApplicationResources{
+	DriverResources:   testResource,
+	ExecutorResources: testResource,
+	MinExecutorCount:  0,
+	MaxExecutorCount:  0,
 }
 var testPod = &v1.Pod{
 	ObjectMeta: metav1.ObjectMeta{
@@ -41,7 +48,7 @@ var testPod = &v1.Pod{
 func Test_demandResourcesForApplication(t *testing.T) {
 	type args struct {
 		driverPod            *v1.Pod
-		applicationResources *sparkApplicationResources
+		applicationResources *types.SparkApplicationResources
 	}
 	var tests = []struct {
 		name string
@@ -57,9 +64,9 @@ func Test_demandResourcesForApplication(t *testing.T) {
 			want: []demandapi.DemandUnit{
 				{
 					Resources: demandapi.ResourceList{
-						demandapi.ResourceCPU:       testResources.driverResources.CPU,
-						demandapi.ResourceMemory:    testResources.driverResources.Memory,
-						demandapi.ResourceNvidiaGPU: testResources.driverResources.NvidiaGPU,
+						demandapi.ResourceCPU:       testResources.DriverResources.CPU,
+						demandapi.ResourceMemory:    testResources.DriverResources.Memory,
+						demandapi.ResourceNvidiaGPU: testResources.DriverResources.NvidiaGPU,
 					},
 					Count:               1,
 					PodNamesByNamespace: map[string][]string{"test-namespace": {"test-name"}},

--- a/internal/demands/demand_test.go
+++ b/internal/demands/demand_test.go
@@ -15,14 +15,14 @@
 package demands
 
 import (
-	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
-	"github.com/palantir/k8s-spark-scheduler/internal/types"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"reflect"
 	"testing"
 
 	demandapi "github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/scaler/v1alpha2"
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
+	"github.com/palantir/k8s-spark-scheduler/internal/types"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/internal/extender/demand_gc.go
+++ b/internal/extender/demand_gc.go
@@ -16,9 +16,9 @@ package extender
 
 import (
 	"context"
-	"github.com/palantir/k8s-spark-scheduler/internal/demands"
 
 	"github.com/palantir/k8s-spark-scheduler/internal/common/utils"
+	"github.com/palantir/k8s-spark-scheduler/internal/demands"
 	v1 "k8s.io/api/core/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientcache "k8s.io/client-go/tools/cache"

--- a/internal/extender/extendertest/extender_test_utils.go
+++ b/internal/extender/extendertest/extender_test_utils.go
@@ -17,8 +17,6 @@ package extendertest
 import (
 	"context"
 	"fmt"
-	"github.com/palantir/k8s-spark-scheduler/internal/binpacker"
-	"github.com/palantir/k8s-spark-scheduler/internal/demands"
 	"os"
 	"testing"
 
@@ -26,8 +24,10 @@ import (
 	ssclientset "github.com/palantir/k8s-spark-scheduler-lib/pkg/client/clientset/versioned/fake"
 	ssinformers "github.com/palantir/k8s-spark-scheduler-lib/pkg/client/informers/externalversions"
 	"github.com/palantir/k8s-spark-scheduler/config"
+	"github.com/palantir/k8s-spark-scheduler/internal/binpacker"
 	sscache "github.com/palantir/k8s-spark-scheduler/internal/cache"
 	"github.com/palantir/k8s-spark-scheduler/internal/crd"
+	"github.com/palantir/k8s-spark-scheduler/internal/demands"
 	"github.com/palantir/k8s-spark-scheduler/internal/extender"
 	"github.com/palantir/k8s-spark-scheduler/internal/metrics"
 	"github.com/palantir/k8s-spark-scheduler/internal/sort"
@@ -136,8 +136,7 @@ func NewTestExtender(binpackAlgo string, objects ...runtime.Object) (*Harness, e
 
 	wasteMetricsReporter := metrics.NewWasteMetricsReporter(ctx, instanceGroupLabel)
 
-	demandManager := demands.NewDefaultManager()
-	fmt.Println(demandCache)
+	demandManager := demands.NewDefaultManager(fakeKubeClient.CoreV1(), demandCache, binpacker, instanceGroupLabel)
 	sparkSchedulerExtender := extender.NewExtender(
 		nodeLister,
 		sparkPodLister,

--- a/internal/extender/extendertest/extender_test_utils.go
+++ b/internal/extender/extendertest/extender_test_utils.go
@@ -17,6 +17,8 @@ package extendertest
 import (
 	"context"
 	"fmt"
+	"github.com/palantir/k8s-spark-scheduler/internal/binpacker"
+	"github.com/palantir/k8s-spark-scheduler/internal/demands"
 	"os"
 	"testing"
 
@@ -129,11 +131,13 @@ func NewTestExtender(binpackAlgo string, objects ...runtime.Object) (*Harness, e
 
 	isFIFO := true
 	fifoConfig := config.FifoConfig{}
-	binpacker := extender.SelectBinpacker(binpackAlgo)
+	binpacker := binpacker.SelectBinpacker(binpackAlgo)
 	shouldScheduleDynamicallyAllocatedExecutorsInSameAZ := true
 
 	wasteMetricsReporter := metrics.NewWasteMetricsReporter(ctx, instanceGroupLabel)
 
+	demandManager := demands.NewDefaultManager()
+	fmt.Println(demandCache)
 	sparkSchedulerExtender := extender.NewExtender(
 		nodeLister,
 		sparkPodLister,
@@ -141,7 +145,7 @@ func NewTestExtender(binpackAlgo string, objects ...runtime.Object) (*Harness, e
 		softReservationStore,
 		resourceReservationManager,
 		fakeKubeClient.CoreV1(),
-		demandCache,
+		demandManager,
 		fakeAPIExtensionsClient,
 		isFIFO,
 		fifoConfig,

--- a/internal/extender/failover.go
+++ b/internal/extender/failover.go
@@ -164,7 +164,6 @@ func (r *reconciler) syncResourceReservations(ctx context.Context, sp *sparkPods
 
 func (r *reconciler) syncDemands(ctx context.Context, sp *sparkPods) {
 	if sp.inconsistentDriver != nil {
-		// r.demands.
 		r.demands.DeleteDemandIfExists(ctx, sp.inconsistentDriver, "Reconciler")
 	}
 	for _, e := range sp.inconsistentExecutors {

--- a/internal/extender/failover.go
+++ b/internal/extender/failover.go
@@ -16,8 +16,6 @@ package extender
 
 import (
 	"context"
-	"github.com/palantir/k8s-spark-scheduler/internal/demands"
-	"github.com/palantir/k8s-spark-scheduler/internal/types"
 	"math"
 	"sort"
 
@@ -27,6 +25,8 @@ import (
 	"github.com/palantir/k8s-spark-scheduler/internal/cache"
 	"github.com/palantir/k8s-spark-scheduler/internal/common"
 	"github.com/palantir/k8s-spark-scheduler/internal/common/utils"
+	"github.com/palantir/k8s-spark-scheduler/internal/demands"
+	"github.com/palantir/k8s-spark-scheduler/internal/types"
 	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	v1 "k8s.io/api/core/v1"

--- a/internal/extender/failover.go
+++ b/internal/extender/failover.go
@@ -16,6 +16,8 @@ package extender
 
 import (
 	"context"
+	"github.com/palantir/k8s-spark-scheduler/internal/demands"
+	"github.com/palantir/k8s-spark-scheduler/internal/types"
 	"math"
 	"sort"
 
@@ -54,7 +56,15 @@ func (s *SparkSchedulerExtender) syncResourceReservationsAndDemands(ctx context.
 	staleSparkPods := unreservedSparkPodsBySparkID(ctx, rrs, s.softReservationStore, pods)
 	svc1log.FromContext(ctx).Info("starting reconciliation", svc1log.SafeParam("appCount", len(staleSparkPods)))
 
-	r := &reconciler{s.podLister, s.resourceReservations, s.softReservationStore, s.demands, availableResources, orderedNodes, s.instanceGroupLabel}
+	r := &reconciler{
+		podLister:            s.podLister,
+		resourceReservations: s.resourceReservations,
+		softReservations:     s.softReservationStore,
+		demands:              s.demandsManager,
+		availableResources:   availableResources,
+		orderedNodes:         orderedNodes,
+		instanceGroupLabel:   s.instanceGroupLabel,
+	}
 
 	extraExecutorsWithNoRRs := make(map[string][]*v1.Pod)
 	for _, sp := range staleSparkPods {
@@ -86,7 +96,7 @@ type reconciler struct {
 	podLister            *SparkPodLister
 	resourceReservations *cache.ResourceReservationCache
 	softReservations     *cache.SoftReservationStore
-	demands              *cache.SafeDemandCache
+	demands              demands.Manager
 	availableResources   map[instanceGroup]resources.NodeGroupResources
 	orderedNodes         map[instanceGroup][]*v1.Node
 	instanceGroupLabel   string
@@ -128,7 +138,7 @@ func (r *reconciler) syncResourceReservations(ctx context.Context, sp *sparkPods
 		}
 		ig, _ := internal.FindInstanceGroupFromPodSpec(sp.inconsistentDriver.Spec, r.instanceGroupLabel)
 		instanceGroup := instanceGroup(ig)
-		endIdx := int(math.Min(float64(len(sp.inconsistentExecutors)), float64(appResources.minExecutorCount)))
+		endIdx := int(math.Min(float64(len(sp.inconsistentExecutors)), float64(appResources.MinExecutorCount)))
 		executorsUpToMin := sp.inconsistentExecutors[0:endIdx]
 		extraExecutors = sp.inconsistentExecutors[endIdx:]
 
@@ -154,10 +164,11 @@ func (r *reconciler) syncResourceReservations(ctx context.Context, sp *sparkPods
 
 func (r *reconciler) syncDemands(ctx context.Context, sp *sparkPods) {
 	if sp.inconsistentDriver != nil {
-		DeleteDemandIfExists(ctx, r.demands, sp.inconsistentDriver, "Reconciler")
+		// r.demands.
+		r.demands.DeleteDemandIfExists(ctx, sp.inconsistentDriver, "Reconciler")
 	}
 	for _, e := range sp.inconsistentExecutors {
-		DeleteDemandIfExists(ctx, r.demands, e, "Reconciler")
+		r.demands.DeleteDemandIfExists(ctx, e, "Reconciler")
 	}
 }
 
@@ -182,15 +193,15 @@ func (r *reconciler) syncSoftReservations(ctx context.Context, extraExecutorsByA
 		}
 
 		for i, extraExecutor := range extraExecutors {
-			if i >= (applicationResources.maxExecutorCount - applicationResources.minExecutorCount) {
+			if i >= (applicationResources.MaxExecutorCount - applicationResources.MinExecutorCount) {
 				break
 			}
 			err := r.softReservations.AddReservationForPod(ctx, appID, extraExecutor.Name, v1beta2.Reservation{
 				Node: extraExecutor.Spec.NodeName,
 				Resources: v1beta2.ResourceList{
-					string(v1beta2.ResourceCPU):       &applicationResources.executorResources.CPU,
-					string(v1beta2.ResourceMemory):    &applicationResources.executorResources.Memory,
-					string(v1beta2.ResourceNvidiaGPU): &applicationResources.executorResources.NvidiaGPU,
+					string(v1beta2.ResourceCPU):       &applicationResources.ExecutorResources.CPU,
+					string(v1beta2.ResourceMemory):    &applicationResources.ExecutorResources.Memory,
+					string(v1beta2.ResourceNvidiaGPU): &applicationResources.ExecutorResources.NvidiaGPU,
 				},
 			})
 			if err != nil {
@@ -223,7 +234,7 @@ func (r *reconciler) syncApplicationSoftReservations(ctx context.Context) error 
 			continue
 		}
 
-		if appResources.maxExecutorCount > appResources.minExecutorCount {
+		if appResources.MaxExecutorCount > appResources.MinExecutorCount {
 			r.softReservations.CreateSoftReservationIfNotExists(d.Labels[common.SparkAppIDLabel])
 		}
 	}
@@ -353,16 +364,16 @@ func (r *reconciler) constructResourceReservation(
 
 	var reservedNodeNames []string
 	var reservedResources resources.NodeGroupResources
-	executorCountToAssignNodes := applicationResources.minExecutorCount - len(executors)
+	executorCountToAssignNodes := applicationResources.MinExecutorCount - len(executors)
 	if executorCountToAssignNodes > 0 {
-		reservedNodeNames, reservedResources = findNodes(executorCountToAssignNodes, applicationResources.executorResources, availableResources, nodes)
+		reservedNodeNames, reservedResources = findNodes(executorCountToAssignNodes, applicationResources.ExecutorResources, availableResources, nodes)
 		if len(reservedNodeNames) < executorCountToAssignNodes {
 			svc1log.FromContext(ctx).Error("could not reserve space for all executors",
 				svc1log.SafeParams(internal.PodSafeParams(*driver)))
 		}
 	}
 
-	executorNodes := make([]string, 0, applicationResources.minExecutorCount)
+	executorNodes := make([]string, 0, applicationResources.MinExecutorCount)
 	for _, e := range executors {
 		executorNodes = append(executorNodes, e.Spec.NodeName)
 	}
@@ -371,15 +382,15 @@ func (r *reconciler) constructResourceReservation(
 		driver.Spec.NodeName,
 		executorNodes,
 		driver,
-		applicationResources.driverResources,
-		applicationResources.executorResources)
+		applicationResources.DriverResources,
+		applicationResources.ExecutorResources)
 	for i, e := range executors {
 		rr.Status.Pods[executorReservationName(i)] = e.Name
 	}
 	return rr, reservedResources, nil
 }
 
-func (r *reconciler) getAppResources(ctx context.Context, sp *sparkPods) (*sparkApplicationResources, error) {
+func (r *reconciler) getAppResources(ctx context.Context, sp *sparkPods) (*types.SparkApplicationResources, error) {
 	var driver *v1.Pod
 	if sp.inconsistentDriver != nil {
 		driver = sp.inconsistentDriver

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -16,6 +16,8 @@ package extender
 
 import (
 	"context"
+	binpacker2 "github.com/palantir/k8s-spark-scheduler/internal/binpacker"
+	"github.com/palantir/k8s-spark-scheduler/internal/demands"
 	"time"
 
 	demandapi "github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/scaler/v1alpha2"
@@ -69,12 +71,13 @@ type SparkSchedulerExtender struct {
 	coreClient                 corev1.CoreV1Interface
 	nodeSorter                 *ns.NodeSorter
 
-	demands             *cache.SafeDemandCache
+	// demands             *cache.SafeDemandCache
 	apiExtensionsClient apiextensionsclientset.Interface
+	demandsManager      demands.Manager
 
 	isFIFO                                              bool
 	fifoConfig                                          config.FifoConfig
-	binpacker                                           *Binpacker
+	binpacker                                           *binpacker2.Binpacker
 	shouldScheduleDynamicallyAllocatedExecutorsInSameAZ bool
 	overheadComputer                                    *OverheadComputer
 	lastRequest                                         time.Time
@@ -91,11 +94,11 @@ func NewExtender(
 	softReservationStore *cache.SoftReservationStore,
 	resourceReservationManager *ResourceReservationManager,
 	coreClient corev1.CoreV1Interface,
-	demands *cache.SafeDemandCache,
+	demandsManager demands.Manager,
 	apiExtensionsClient apiextensionsclientset.Interface,
 	isFIFO bool,
 	fifoConfig config.FifoConfig,
-	binpacker *Binpacker,
+	binpacker *binpacker2.Binpacker,
 	shouldScheduleDynamicallyAllocatedExecutorsInSameAZ bool,
 	overheadComputer *OverheadComputer,
 	instanceGroupLabel string,
@@ -108,7 +111,7 @@ func NewExtender(
 		softReservationStore:       softReservationStore,
 		resourceReservationManager: resourceReservationManager,
 		coreClient:                 coreClient,
-		demands:                    demands,
+		demandsManager:             demandsManager,
 		apiExtensionsClient:        apiExtensionsClient,
 		isFIFO:                     isFIFO,
 		fifoConfig:                 fifoConfig,
@@ -170,10 +173,10 @@ func (s *SparkSchedulerExtender) Predicate(ctx context.Context, args schedulerap
 			instanceGroup,
 			args.Pod.Labels[common.SparkAppIDLabel],
 			*args.Pod,
-			appResources.driverResources,
-			appResources.executorResources,
-			appResources.minExecutorCount,
-			appResources.maxExecutorCount)
+			appResources.DriverResources,
+			appResources.ExecutorResources,
+			appResources.MinExecutorCount,
+			appResources.MaxExecutorCount)
 	}
 
 	logger.Info("scheduling pod to node", svc1log.SafeParam("nodeName", nodeName))
@@ -209,7 +212,7 @@ func (s *SparkSchedulerExtender) selectNode(ctx context.Context, instanceGroup s
 	case common.Executor:
 		node, outcome, err := s.selectExecutorNode(ctx, pod, nodeNames)
 		if s.isSuccessOutcome(outcome) {
-			s.removeDemandIfExists(ctx, pod)
+			s.demandsManager.DeleteDemandIfExists(ctx, pod, "SparkSchedulerExtender")
 		}
 		return node, outcome, err
 	default:
@@ -235,9 +238,9 @@ func (s *SparkSchedulerExtender) fitEarlierDrivers(
 		}
 		packingResult := s.binpacker.BinpackFunc(
 			ctx,
-			applicationResources.driverResources,
-			applicationResources.executorResources,
-			applicationResources.minExecutorCount,
+			applicationResources.DriverResources,
+			applicationResources.ExecutorResources,
+			applicationResources.MinExecutorCount,
 			nodeNames, executorNodeNames, availableNodesSchedulingMetadata)
 		if !packingResult.HasCapacity {
 			if s.shouldSkipDriverFifo(driver, instanceGroup) {
@@ -251,8 +254,8 @@ func (s *SparkSchedulerExtender) fitEarlierDrivers(
 		}
 
 		availableNodesSchedulingMetadata.SubtractUsageIfExists(sparkResourceUsage(
-			applicationResources.driverResources,
-			applicationResources.executorResources,
+			applicationResources.DriverResources,
+			applicationResources.ExecutorResources,
 			packingResult.DriverNode,
 			packingResult.ExecutorNodes))
 	}
@@ -311,16 +314,16 @@ func (s *SparkSchedulerExtender) selectDriverNode(
 		}
 		ok := s.fitEarlierDrivers(ctx, instanceGroup, queuedDrivers, driverNodeNames, executorNodeNames, availableNodesSchedulingMetadata)
 		if !ok {
-			s.createDemandForApplicationInAnyZone(ctx, driver, applicationResources)
+			s.demandsManager.CreateDemandForApplicationInAnyZone(ctx, driver, applicationResources)
 			return "", failureEarlierDriver, werror.Error("earlier drivers do not fit to the cluster")
 		}
 	}
 
 	packingResult := s.binpacker.BinpackFunc(
 		ctx,
-		applicationResources.driverResources,
-		applicationResources.executorResources,
-		applicationResources.minExecutorCount,
+		applicationResources.DriverResources,
+		applicationResources.ExecutorResources,
+		applicationResources.MinExecutorCount,
 		driverNodeNames,
 		executorNodeNames,
 		availableNodesSchedulingMetadata)
@@ -328,10 +331,10 @@ func (s *SparkSchedulerExtender) selectDriverNode(
 
 	svc1log.FromContext(ctx).Debug("binpacking result",
 		svc1log.SafeParam("availableNodesSchedulingMetadata", availableNodesSchedulingMetadata),
-		svc1log.SafeParam("driverResources", applicationResources.driverResources),
-		svc1log.SafeParam("executorResources", applicationResources.executorResources),
-		svc1log.SafeParam("minExecutorCount", applicationResources.minExecutorCount),
-		svc1log.SafeParam("maxExecutorCount", applicationResources.maxExecutorCount),
+		svc1log.SafeParam("driverResources", applicationResources.DriverResources),
+		svc1log.SafeParam("executorResources", applicationResources.ExecutorResources),
+		svc1log.SafeParam("minExecutorCount", applicationResources.MinExecutorCount),
+		svc1log.SafeParam("maxExecutorCount", applicationResources.MaxExecutorCount),
 		svc1log.SafeParam("hasCapacity", packingResult.HasCapacity),
 		svc1log.SafeParam("candidateDriverNodes", nodeNames),
 		svc1log.SafeParam("candidateExecutorNodes", executorNodeNames),
@@ -343,13 +346,13 @@ func (s *SparkSchedulerExtender) selectDriverNode(
 		svc1log.SafeParam("avg packing efficiency Max", efficiency.Max),
 		svc1log.SafeParam("binpacker", s.binpacker.Name))
 	if !packingResult.HasCapacity {
-		s.createDemandForApplicationInAnyZone(ctx, driver, applicationResources)
+		s.demandsManager.CreateDemandForApplicationInAnyZone(ctx, driver, applicationResources)
 		return "", failureFit, werror.Error("application does not fit to the cluster")
 	}
 
 	metrics.ReportPackingEfficiency(ctx, instanceGroup, s.binpacker.Name, efficiency)
 
-	s.removeDemandIfExists(ctx, driver)
+	s.demandsManager.DeleteDemandIfExists(ctx, driver, "SparkSchedulerExtender")
 	metrics.ReportInitialDriverExecutorCollocationMetric(ctx, instanceGroup, packingResult.DriverNode, packingResult.ExecutorNodes)
 	metrics.ReportInitialNodeCountMetrics(ctx, instanceGroup, packingResult.ExecutorNodes)
 	metrics.ReportCrossZoneMetric(ctx, instanceGroup, packingResult.DriverNode, packingResult.ExecutorNodes, availableNodes)
@@ -598,7 +601,7 @@ func (s *SparkSchedulerExtender) rescheduleExecutor(ctx context.Context, executo
 	if err != nil {
 		return "", failureInternal, err
 	}
-	executorResources := &resources.Resources{CPU: sparkResources.executorResources.CPU, Memory: sparkResources.executorResources.Memory, NvidiaGPU: sparkResources.executorResources.NvidiaGPU}
+	executorResources := &resources.Resources{CPU: sparkResources.ExecutorResources.CPU, Memory: sparkResources.ExecutorResources.Memory, NvidiaGPU: sparkResources.ExecutorResources.NvidiaGPU}
 	availableNodes := s.getNodes(ctx, nodeNames)
 
 	shouldScheduleIntoSingleAZ := false
@@ -647,7 +650,7 @@ func (s *SparkSchedulerExtender) rescheduleExecutor(ctx context.Context, executo
 		potentialSuccessOutcome = successScheduledExtraExecutor
 	}
 
-	if s.binpacker.Name == SingleAzMinimalFragmentation {
+	if s.binpacker.Name == binpacker2.SingleAzMinimalFragmentation {
 		name, ok := s.rescheduleExecutorWithMinimalFragmentation(executor, executorNodeNames, availableNodesSchedulingMetadata, overhead, executorResources)
 		if ok {
 			return name, potentialSuccessOutcome, nil
@@ -663,9 +666,9 @@ func (s *SparkSchedulerExtender) rescheduleExecutor(ctx context.Context, executo
 		svc1log.FromContext(ctx).Info("Failed to find space in zone for additional executor, creating a demand", svc1log.SafeParam("zone", singleAzZone))
 		metrics.IncrementSingleAzDynamicAllocationPackFailure(ctx, singleAzZone)
 		demandZone := demandapi.Zone(singleAzZone)
-		s.createDemandForExecutorInSpecificZone(ctx, executor, executorResources, &demandZone)
+		s.demandsManager.CreateDemandForExecutorInSpecificZone(ctx, executor, executorResources, &demandZone)
 	} else {
-		s.createDemandForExecutorInAnyZone(ctx, executor, executorResources)
+		s.demandsManager.CreateDemandForExecutorInAnyZone(ctx, executor, executorResources)
 	}
 	return "", failureFit, werror.ErrorWithContextParams(ctx, "not enough capacity to reschedule the executor")
 }

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -71,7 +71,6 @@ type SparkSchedulerExtender struct {
 	coreClient                 corev1.CoreV1Interface
 	nodeSorter                 *ns.NodeSorter
 
-	// demands             *cache.SafeDemandCache
 	apiExtensionsClient apiextensionsclientset.Interface
 	demandsManager      demands.Manager
 

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -24,7 +24,7 @@ import (
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"github.com/palantir/k8s-spark-scheduler/config"
 	"github.com/palantir/k8s-spark-scheduler/internal"
-	binpacker2 "github.com/palantir/k8s-spark-scheduler/internal/binpacker"
+	internalbinpacker "github.com/palantir/k8s-spark-scheduler/internal/binpacker"
 	"github.com/palantir/k8s-spark-scheduler/internal/cache"
 	"github.com/palantir/k8s-spark-scheduler/internal/common"
 	"github.com/palantir/k8s-spark-scheduler/internal/common/utils"
@@ -76,7 +76,7 @@ type SparkSchedulerExtender struct {
 
 	isFIFO                                              bool
 	fifoConfig                                          config.FifoConfig
-	binpacker                                           *binpacker2.Binpacker
+	binpacker                                           *internalbinpacker.Binpacker
 	shouldScheduleDynamicallyAllocatedExecutorsInSameAZ bool
 	overheadComputer                                    *OverheadComputer
 	lastRequest                                         time.Time
@@ -97,7 +97,7 @@ func NewExtender(
 	apiExtensionsClient apiextensionsclientset.Interface,
 	isFIFO bool,
 	fifoConfig config.FifoConfig,
-	binpacker *binpacker2.Binpacker,
+	binpacker *internalbinpacker.Binpacker,
 	shouldScheduleDynamicallyAllocatedExecutorsInSameAZ bool,
 	overheadComputer *OverheadComputer,
 	instanceGroupLabel string,
@@ -649,7 +649,7 @@ func (s *SparkSchedulerExtender) rescheduleExecutor(ctx context.Context, executo
 		potentialSuccessOutcome = successScheduledExtraExecutor
 	}
 
-	if s.binpacker.Name == binpacker2.SingleAzMinimalFragmentation {
+	if s.binpacker.Name == internalbinpacker.SingleAzMinimalFragmentation {
 		name, ok := s.rescheduleExecutorWithMinimalFragmentation(executor, executorNodeNames, availableNodesSchedulingMetadata, overhead, executorResources)
 		if ok {
 			return name, potentialSuccessOutcome, nil

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -16,8 +16,6 @@ package extender
 
 import (
 	"context"
-	binpacker2 "github.com/palantir/k8s-spark-scheduler/internal/binpacker"
-	"github.com/palantir/k8s-spark-scheduler/internal/demands"
 	"time"
 
 	demandapi "github.com/palantir/k8s-spark-scheduler-lib/pkg/apis/scaler/v1alpha2"
@@ -26,9 +24,11 @@ import (
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"github.com/palantir/k8s-spark-scheduler/config"
 	"github.com/palantir/k8s-spark-scheduler/internal"
+	binpacker2 "github.com/palantir/k8s-spark-scheduler/internal/binpacker"
 	"github.com/palantir/k8s-spark-scheduler/internal/cache"
 	"github.com/palantir/k8s-spark-scheduler/internal/common"
 	"github.com/palantir/k8s-spark-scheduler/internal/common/utils"
+	"github.com/palantir/k8s-spark-scheduler/internal/demands"
 	"github.com/palantir/k8s-spark-scheduler/internal/events"
 	"github.com/palantir/k8s-spark-scheduler/internal/metrics"
 	ns "github.com/palantir/k8s-spark-scheduler/internal/sort"

--- a/internal/extender/resource_test.go
+++ b/internal/extender/resource_test.go
@@ -16,9 +16,9 @@ package extender_test
 
 import (
 	"fmt"
-	"github.com/palantir/k8s-spark-scheduler/internal/binpacker"
 	"testing"
 
+	"github.com/palantir/k8s-spark-scheduler/internal/binpacker"
 	"github.com/palantir/k8s-spark-scheduler/internal/extender/extendertest"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/internal/extender/resource_test.go
+++ b/internal/extender/resource_test.go
@@ -16,9 +16,9 @@ package extender_test
 
 import (
 	"fmt"
+	"github.com/palantir/k8s-spark-scheduler/internal/binpacker"
 	"testing"
 
-	"github.com/palantir/k8s-spark-scheduler/internal/extender"
 	"github.com/palantir/k8s-spark-scheduler/internal/extender/extendertest"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -31,7 +31,7 @@ func TestScheduler(t *testing.T) {
 	podsToSchedule := extendertest.StaticAllocationSparkPods("2-executor-app", 2)
 
 	testHarness, err := extendertest.NewTestExtender(
-		extender.SingleAzTightlyPack,
+		binpacker.SingleAzTightlyPack,
 		&node1,
 		&node2,
 		&podsToSchedule[0],
@@ -78,7 +78,7 @@ func TestMinimalFragmentation(t *testing.T) {
 	podsToSchedule := extendertest.DynamicAllocationSparkPods("dynamic-app", 1, 2)
 
 	testHarness, err := extendertest.NewTestExtender(
-		extender.SingleAzMinimalFragmentation,
+		binpacker.SingleAzMinimalFragmentation,
 		&node1,
 		&node2,
 		&staticPodsToSchedule[0],
@@ -131,7 +131,7 @@ func TestMinimalFragmentationEdgeCase(t *testing.T) {
 	dynamicApp := extendertest.DynamicAllocationSparkPodsWithSizes("dyn-app", 0, 1, "1", "4", "1", "3")
 
 	testHarness, err := extendertest.NewTestExtender(
-		extender.SingleAzMinimalFragmentation,
+		binpacker.SingleAzMinimalFragmentation,
 		&node1,
 		&node2,
 		&staticApp[0],
@@ -307,7 +307,7 @@ func TestDynamicAllocationScheduling(t *testing.T) {
 			for i := range test.podsToSchedule {
 				harnessArgs = append(harnessArgs, &test.podsToSchedule[i])
 			}
-			testHarness, err := extendertest.NewTestExtender(extender.SingleAzTightlyPack, harnessArgs...)
+			testHarness, err := extendertest.NewTestExtender(binpacker.SingleAzTightlyPack, harnessArgs...)
 			if err != nil {
 				t.Fatal("Could not setup test extender")
 			}

--- a/internal/extender/resourcereservations.go
+++ b/internal/extender/resourcereservations.go
@@ -17,6 +17,7 @@ package extender
 import (
 	"context"
 	"fmt"
+	"github.com/palantir/k8s-spark-scheduler/internal/types"
 	"math"
 	"sync"
 
@@ -111,12 +112,12 @@ func (rrm *ResourceReservationManager) PodHasReservation(ctx context.Context, po
 func (rrm *ResourceReservationManager) CreateReservations(
 	ctx context.Context,
 	driver *v1.Pod,
-	applicationResources *sparkApplicationResources,
+	applicationResources *types.SparkApplicationResources,
 	driverNode string,
 	executorNodes []string) (*v1beta2.ResourceReservation, error) {
 	rr, ok := rrm.GetResourceReservation(driver.Labels[common.SparkAppIDLabel], driver.Namespace)
 	if !ok {
-		rr = newResourceReservation(driverNode, executorNodes, driver, applicationResources.driverResources, applicationResources.executorResources)
+		rr = newResourceReservation(driverNode, executorNodes, driver, applicationResources.DriverResources, applicationResources.ExecutorResources)
 		svc1log.FromContext(ctx).Debug("creating executor resource reservations", svc1log.SafeParams(logging.RRSafeParamV1Beta2(rr)))
 		err := rrm.resourceReservations.Create(rr)
 		if err != nil {
@@ -124,7 +125,7 @@ func (rrm *ResourceReservationManager) CreateReservations(
 		}
 	}
 
-	if applicationResources.maxExecutorCount > applicationResources.minExecutorCount {
+	if applicationResources.MaxExecutorCount > applicationResources.MinExecutorCount {
 		// only create soft reservations for applications which can request extra executors
 		svc1log.FromContext(ctx).Debug("creating soft reservations for application", svc1log.SafeParam("appID", driver.Labels[common.SparkAppIDLabel]))
 		rrm.softReservationStore.CreateSoftReservationIfNotExists(driver.Labels[common.SparkAppIDLabel])
@@ -350,9 +351,9 @@ func (rrm *ResourceReservationManager) bindExecutorToSoftReservation(ctx context
 	softReservation := v1beta2.Reservation{
 		Node: node,
 		Resources: v1beta2.ResourceList{
-			string(v1beta2.ResourceCPU):       &sparkResources.executorResources.CPU,
-			string(v1beta2.ResourceMemory):    &sparkResources.executorResources.Memory,
-			string(v1beta2.ResourceNvidiaGPU): &sparkResources.executorResources.NvidiaGPU,
+			string(v1beta2.ResourceCPU):       &sparkResources.ExecutorResources.CPU,
+			string(v1beta2.ResourceMemory):    &sparkResources.ExecutorResources.Memory,
+			string(v1beta2.ResourceNvidiaGPU): &sparkResources.ExecutorResources.NvidiaGPU,
 		},
 	}
 	return rrm.softReservationStore.AddReservationForPod(ctx, driver.Labels[common.SparkAppIDLabel], executor.Name, softReservation)
@@ -396,7 +397,7 @@ func (rrm *ResourceReservationManager) getFreeSoftReservationSpots(ctx context.C
 	if err != nil {
 		return 0, err
 	}
-	maxAllowedExtraExecutors := sparkResources.maxExecutorCount - sparkResources.minExecutorCount
+	maxAllowedExtraExecutors := sparkResources.MaxExecutorCount - sparkResources.MinExecutorCount
 	return int(math.Max(float64(maxAllowedExtraExecutors-usedSoftReservationCount), 0)), nil
 }
 

--- a/internal/extender/resourcereservations.go
+++ b/internal/extender/resourcereservations.go
@@ -17,7 +17,6 @@ package extender
 import (
 	"context"
 	"fmt"
-	"github.com/palantir/k8s-spark-scheduler/internal/types"
 	"math"
 	"sync"
 
@@ -29,6 +28,7 @@ import (
 	"github.com/palantir/k8s-spark-scheduler/internal/common"
 	"github.com/palantir/k8s-spark-scheduler/internal/common/utils"
 	"github.com/palantir/k8s-spark-scheduler/internal/metrics"
+	"github.com/palantir/k8s-spark-scheduler/internal/types"
 	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	v1 "k8s.io/api/core/v1"

--- a/internal/extender/sparkpods.go
+++ b/internal/extender/sparkpods.go
@@ -17,13 +17,13 @@ package extender
 import (
 	"context"
 	"fmt"
-	"github.com/palantir/k8s-spark-scheduler/internal/types"
 	"sort"
 	"strconv"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"github.com/palantir/k8s-spark-scheduler/internal"
 	"github.com/palantir/k8s-spark-scheduler/internal/common"
+	"github.com/palantir/k8s-spark-scheduler/internal/types"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"

--- a/internal/extender/sparkpods.go
+++ b/internal/extender/sparkpods.go
@@ -17,6 +17,7 @@ package extender
 import (
 	"context"
 	"fmt"
+	"github.com/palantir/k8s-spark-scheduler/internal/types"
 	"sort"
 	"strconv"
 
@@ -28,13 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	corelisters "k8s.io/client-go/listers/core/v1"
 )
-
-type sparkApplicationResources struct {
-	driverResources   *resources.Resources
-	executorResources *resources.Resources
-	minExecutorCount  int
-	maxExecutorCount  int
-}
 
 // SparkPodLister is a PodLister which can also list drivers per node selector
 type SparkPodLister struct {
@@ -76,7 +70,7 @@ func filterToEarliestAndSort(driver *v1.Pod, allDrivers []*v1.Pod, instanceGroup
 	return earlierDrivers
 }
 
-func sparkResources(ctx context.Context, pod *v1.Pod) (*sparkApplicationResources, error) {
+func sparkResources(ctx context.Context, pod *v1.Pod) (*types.SparkApplicationResources, error) {
 	parsedResources := map[string]resource.Quantity{}
 	dynamicAllocationEnabled := false
 	if daLabel, ok := pod.Annotations[common.DynamicAllocationEnabled]; ok {
@@ -134,7 +128,12 @@ func sparkResources(ctx context.Context, pod *v1.Pod) (*sparkApplicationResource
 		Memory:    parsedResources[common.ExecutorMemory],
 		NvidiaGPU: parsedResources[common.ExecutorNvidiaGPUs],
 	}
-	return &sparkApplicationResources{driverResources, executorResources, minExecutorCount, maxExecutorCount}, nil
+	return &types.SparkApplicationResources{
+		DriverResources:   driverResources,
+		ExecutorResources: executorResources,
+		MinExecutorCount:  minExecutorCount,
+		MaxExecutorCount:  maxExecutorCount,
+	}, nil
 }
 
 func sparkResourceUsage(driverResources, executorResources *resources.Resources, driverNode string, executorNodes []string) resources.NodeGroupResources {

--- a/internal/extender/sparkpods_test.go
+++ b/internal/extender/sparkpods_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 	"github.com/palantir/k8s-spark-scheduler/internal/common"
+	internaltypes "github.com/palantir/k8s-spark-scheduler/internal/types"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,7 +41,7 @@ func TestSparkResources(t *testing.T) {
 	tests := []struct {
 		name                         string
 		pod                          v1.Pod
-		expectedApplicationResources *sparkApplicationResources
+		expectedApplicationResources *internaltypes.SparkApplicationResources
 	}{{
 		name: "parses static allocation pod annotations into resources",
 		pod: v1.Pod{
@@ -56,11 +57,11 @@ func TestSparkResources(t *testing.T) {
 				},
 			},
 		},
-		expectedApplicationResources: &sparkApplicationResources{
-			driverResources:   createResources(1, 2432*1024*1024, 1),
-			executorResources: createResources(2, 6758*1024*1024, 1),
-			minExecutorCount:  2,
-			maxExecutorCount:  2,
+		expectedApplicationResources: &internaltypes.SparkApplicationResources{
+			DriverResources:   createResources(1, 2432*1024*1024, 1),
+			ExecutorResources: createResources(2, 6758*1024*1024, 1),
+			MinExecutorCount:  2,
+			MaxExecutorCount:  2,
 		},
 	}, {
 		name: "parses dynamic allocation pod annotations into resources",
@@ -79,11 +80,11 @@ func TestSparkResources(t *testing.T) {
 				},
 			},
 		},
-		expectedApplicationResources: &sparkApplicationResources{
-			driverResources:   createResources(1, 2432*1024*1024, 1),
-			executorResources: createResources(2, 6758*1024*1024, 1),
-			minExecutorCount:  2,
-			maxExecutorCount:  5,
+		expectedApplicationResources: &internaltypes.SparkApplicationResources{
+			DriverResources:   createResources(1, 2432*1024*1024, 1),
+			ExecutorResources: createResources(2, 6758*1024*1024, 1),
+			MinExecutorCount:  2,
+			MaxExecutorCount:  5,
 		},
 	}, {
 		name: "parses static allocation pod annotations into resources when no gpu annotation is present",
@@ -98,11 +99,11 @@ func TestSparkResources(t *testing.T) {
 				},
 			},
 		},
-		expectedApplicationResources: &sparkApplicationResources{
-			driverResources:   createResources(1, 2432*1024*1024, 0),
-			executorResources: createResources(2, 6758*1024*1024, 0),
-			minExecutorCount:  2,
-			maxExecutorCount:  2,
+		expectedApplicationResources: &internaltypes.SparkApplicationResources{
+			DriverResources:   createResources(1, 2432*1024*1024, 0),
+			ExecutorResources: createResources(2, 6758*1024*1024, 0),
+			MinExecutorCount:  2,
+			MaxExecutorCount:  2,
 		},
 	},
 	}
@@ -113,25 +114,25 @@ func TestSparkResources(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error: %v", err)
 			}
-			cacheQuantities(applicationResources.driverResources)
-			cacheQuantities(test.expectedApplicationResources.driverResources)
-			cacheQuantities(applicationResources.executorResources)
-			cacheQuantities(test.expectedApplicationResources.executorResources)
-			if !applicationResources.driverResources.Eq(test.expectedApplicationResources.driverResources) {
+			cacheQuantities(applicationResources.DriverResources)
+			cacheQuantities(test.expectedApplicationResources.DriverResources)
+			cacheQuantities(applicationResources.ExecutorResources)
+			cacheQuantities(test.expectedApplicationResources.ExecutorResources)
+			if !applicationResources.DriverResources.Eq(test.expectedApplicationResources.DriverResources) {
 				t.Fatalf("driverResources are not equal, expected: %v, got: %v",
-					test.expectedApplicationResources.driverResources, applicationResources.driverResources)
+					test.expectedApplicationResources.DriverResources, applicationResources.DriverResources)
 			}
-			if !applicationResources.executorResources.Eq(test.expectedApplicationResources.executorResources) {
+			if !applicationResources.ExecutorResources.Eq(test.expectedApplicationResources.ExecutorResources) {
 				t.Fatalf("executorResources are not equal, expected: %v, got: %v",
-					test.expectedApplicationResources.executorResources, applicationResources.executorResources)
+					test.expectedApplicationResources.ExecutorResources, applicationResources.ExecutorResources)
 			}
-			if applicationResources.minExecutorCount != test.expectedApplicationResources.minExecutorCount {
+			if applicationResources.MinExecutorCount != test.expectedApplicationResources.MinExecutorCount {
 				t.Fatalf("minExecutorCount not equal to ExecutorCount in static allocation, expected: %v, got: %v",
-					test.expectedApplicationResources.minExecutorCount, applicationResources.minExecutorCount)
+					test.expectedApplicationResources.MinExecutorCount, applicationResources.MinExecutorCount)
 			}
-			if applicationResources.maxExecutorCount != test.expectedApplicationResources.maxExecutorCount {
+			if applicationResources.MaxExecutorCount != test.expectedApplicationResources.MaxExecutorCount {
 				t.Fatalf("maxExecutorCount not equal to ExecutorCount in static allocation, expected: %v, got: %v",
-					test.expectedApplicationResources.maxExecutorCount, applicationResources.maxExecutorCount)
+					test.expectedApplicationResources.MaxExecutorCount, applicationResources.MaxExecutorCount)
 			}
 		})
 	}

--- a/internal/extender/unschedulablepods.go
+++ b/internal/extender/unschedulablepods.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
-	binpacker2 "github.com/palantir/k8s-spark-scheduler/internal/binpacker"
+	internalbinpacker "github.com/palantir/k8s-spark-scheduler/internal/binpacker"
 	"github.com/palantir/k8s-spark-scheduler/internal/common"
 	"github.com/palantir/k8s-spark-scheduler/internal/common/utils"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -46,7 +46,7 @@ type UnschedulablePodMarker struct {
 	podLister        corelisters.PodLister
 	coreClient       corev1.CoreV1Interface
 	overheadComputer *OverheadComputer
-	binpacker        *binpacker2.Binpacker
+	binpacker        *internalbinpacker.Binpacker
 	timeoutDuration  time.Duration
 }
 
@@ -56,7 +56,7 @@ func NewUnschedulablePodMarker(
 	podLister corelisters.PodLister,
 	coreClient corev1.CoreV1Interface,
 	overheadComputer *OverheadComputer,
-	binpacker *binpacker2.Binpacker,
+	binpacker *internalbinpacker.Binpacker,
 	timeoutDuration time.Duration) *UnschedulablePodMarker {
 
 	if timeoutDuration <= 0 {

--- a/internal/extender/unschedulablepods.go
+++ b/internal/extender/unschedulablepods.go
@@ -16,10 +16,10 @@ package extender
 
 import (
 	"context"
-	binpacker2 "github.com/palantir/k8s-spark-scheduler/internal/binpacker"
 	"time"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
+	binpacker2 "github.com/palantir/k8s-spark-scheduler/internal/binpacker"
 	"github.com/palantir/k8s-spark-scheduler/internal/common"
 	"github.com/palantir/k8s-spark-scheduler/internal/common/utils"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"

--- a/internal/extender/unschedulablepods.go
+++ b/internal/extender/unschedulablepods.go
@@ -16,6 +16,7 @@ package extender
 
 import (
 	"context"
+	binpacker2 "github.com/palantir/k8s-spark-scheduler/internal/binpacker"
 	"time"
 
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
@@ -45,7 +46,7 @@ type UnschedulablePodMarker struct {
 	podLister        corelisters.PodLister
 	coreClient       corev1.CoreV1Interface
 	overheadComputer *OverheadComputer
-	binpacker        *Binpacker
+	binpacker        *binpacker2.Binpacker
 	timeoutDuration  time.Duration
 }
 
@@ -55,7 +56,7 @@ func NewUnschedulablePodMarker(
 	podLister corelisters.PodLister,
 	coreClient corev1.CoreV1Interface,
 	overheadComputer *OverheadComputer,
-	binpacker *Binpacker,
+	binpacker *binpacker2.Binpacker,
 	timeoutDuration time.Duration) *UnschedulablePodMarker {
 
 	if timeoutDuration <= 0 {
@@ -154,9 +155,9 @@ func (u *UnschedulablePodMarker) DoesPodExceedClusterCapacity(ctx context.Contex
 	}
 	packingResult := u.binpacker.BinpackFunc(
 		ctx,
-		applicationResources.driverResources,
-		applicationResources.executorResources,
-		applicationResources.minExecutorCount,
+		applicationResources.DriverResources,
+		applicationResources.ExecutorResources,
+		applicationResources.MinExecutorCount,
 		nodeNames,
 		nodeNames,
 		availableNodesSchedulingMetadata)

--- a/internal/extender/unschedulablepods_test.go
+++ b/internal/extender/unschedulablepods_test.go
@@ -15,9 +15,9 @@
 package extender_test
 
 import (
-	"github.com/palantir/k8s-spark-scheduler/internal/binpacker"
 	"testing"
 
+	"github.com/palantir/k8s-spark-scheduler/internal/binpacker"
 	"github.com/palantir/k8s-spark-scheduler/internal/extender/extendertest"
 )
 

--- a/internal/extender/unschedulablepods_test.go
+++ b/internal/extender/unschedulablepods_test.go
@@ -15,9 +15,9 @@
 package extender_test
 
 import (
+	"github.com/palantir/k8s-spark-scheduler/internal/binpacker"
 	"testing"
 
-	"github.com/palantir/k8s-spark-scheduler/internal/extender"
 	"github.com/palantir/k8s-spark-scheduler/internal/extender/extendertest"
 )
 
@@ -26,7 +26,7 @@ func TestUnschedulablePodMarker(t *testing.T) {
 	node2 := extendertest.NewNode("node2", "zone1")
 
 	testHarness, err := extendertest.NewTestExtender(
-		extender.SingleAzTightlyPack,
+		binpacker.SingleAzTightlyPack,
 		&node1,
 		&node2)
 	if err != nil {
@@ -59,7 +59,7 @@ func TestSchedulerFailsToScheduleWhenNotEnoughNvidiaGPUs(t *testing.T) {
 	podsToSchedule := extendertest.StaticAllocationSparkPodsWithExecutorGPUs("2-executor-app", 2)
 
 	testHarness, err := extendertest.NewTestExtender(
-		extender.SingleAzTightlyPack,
+		binpacker.SingleAzTightlyPack,
 		&node1,
 		&node2,
 		&podsToSchedule[0],

--- a/internal/types/const.go
+++ b/internal/types/const.go
@@ -18,4 +18,5 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+// PodGroupVersionKind is the GroupVersionKind for a pod
 var PodGroupVersionKind = v1.SchemeGroupVersion.WithKind("Pod")

--- a/internal/types/const.go
+++ b/internal/types/const.go
@@ -1,0 +1,5 @@
+package types
+
+import v1 "k8s.io/api/core/v1"
+
+var PodGroupVersionKind = v1.SchemeGroupVersion.WithKind("Pod")

--- a/internal/types/const.go
+++ b/internal/types/const.go
@@ -1,5 +1,21 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package types
 
-import v1 "k8s.io/api/core/v1"
+import (
+	v1 "k8s.io/api/core/v1"
+)
 
 var PodGroupVersionKind = v1.SchemeGroupVersion.WithKind("Pod")

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,6 +1,22 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package types
 
-import "github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
+import (
+	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
+)
 
 type SparkApplicationResources struct {
 	DriverResources   *resources.Resources

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -18,6 +18,7 @@ import (
 	"github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
 )
 
+// SparkApplicationResources holds all resources for a single SparkApplication
 type SparkApplicationResources struct {
 	DriverResources   *resources.Resources
 	ExecutorResources *resources.Resources

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,0 +1,10 @@
+package types
+
+import "github.com/palantir/k8s-spark-scheduler-lib/pkg/resources"
+
+type SparkApplicationResources struct {
+	DriverResources   *resources.Resources
+	ExecutorResources *resources.Resources
+	MinExecutorCount  int
+	MaxExecutorCount  int
+}


### PR DESCRIPTION
- Move the demand processing behind a single interface that can be shared 
- Right now demand manipulation are a combination of static methods and using the raw `SafeDemandCache` struct which makes it impossible to test or mock
- This moves this operations behind a single interface
- Move out `binpacker` to its own package (`binpacker`) so it can be shared
- Move the common object types into their own package (`types`) so it can be shared

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
