### PR TITLE
Add time to bind metrics

### DIFF
--- a/internal/extender/resourcereservations.go
+++ b/internal/extender/resourcereservations.go
@@ -340,10 +340,10 @@ func (rrm *ResourceReservationManager) bindExecutorToResourceReservation(ctx con
 	// only report the metric the first time the reservation is bound
 	if _, ok := resourceReservation.Status.Pods[reservationName]; !ok {
 		// this is the k8s server time, so the duration we're computing only makes sense if clocks are reasonably kept in sync
-		creationMicros := resourceReservation.CreationTimestamp.Time.UnixMicro()
-		now := time.Now().UnixMicro()
-		durationMicros := now - creationMicros
-		metrics.ReportTimeToBindMetrics(ctx, durationMicros)
+		creationMicros := resourceReservation.CreationTimestamp.Time
+		now := time.Now()
+		duration := now.Sub(creationMicros)
+		metrics.ReportTimeToBindMetrics(ctx, duration)
 	}
 	return nil
 }

--- a/internal/extender/resourcereservations.go
+++ b/internal/extender/resourcereservations.go
@@ -342,7 +342,7 @@ func (rrm *ResourceReservationManager) bindExecutorToResourceReservation(ctx con
 		// this is the k8s server time, so the duration we're computing only makes sense if clocks are reasonably kept in sync
 		creationTime := resourceReservation.CreationTimestamp.Time
 		duration := time.Now().Sub(creationTime)
-		metrics.ReportTimeToBindMetrics(ctx, duration)
+		metrics.ReportTimeToFirstBindMetrics(ctx, duration)
 	}
 	return nil
 }

--- a/internal/extender/resourcereservations.go
+++ b/internal/extender/resourcereservations.go
@@ -340,9 +340,8 @@ func (rrm *ResourceReservationManager) bindExecutorToResourceReservation(ctx con
 	// only report the metric the first time the reservation is bound
 	if _, ok := resourceReservation.Status.Pods[reservationName]; !ok {
 		// this is the k8s server time, so the duration we're computing only makes sense if clocks are reasonably kept in sync
-		creationMicros := resourceReservation.CreationTimestamp.Time
-		now := time.Now()
-		duration := now.Sub(creationMicros)
+		creationTime := resourceReservation.CreationTimestamp.Time
+		duration := time.Now().Sub(creationTime)
 		metrics.ReportTimeToBindMetrics(ctx, duration)
 	}
 	return nil

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -371,5 +371,5 @@ func IncrementSingleAzDynamicAllocationPackFailure(ctx context.Context, zone str
 func ReportTimeToBindMetrics(ctx context.Context, durationMicros int64) {
 	timeToBindHist := metrics.FromContext(ctx).Histogram(timeToBind)
 	timeToBindHist.Update(durationMicros)
-	metrics.FromContext(ctx).GaugeFloat64(timeToBindP50).Update(timeToBindHist.Mean())
+	metrics.FromContext(ctx).GaugeFloat64(timeToBindP50).Update(timeToBindHist.Percentile(.5))
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -52,6 +52,8 @@ const (
 	unboundCPUReservations                    = "foundry.spark.scheduler.reservations.unbound.cpu"
 	unboundMemoryReservations                 = "foundry.spark.scheduler.reservations.unbound.memory"
 	unboundNvidiaGPUReservations              = "foundry.spark.scheduler.reservations.unbound.nvidiagpu"
+	timeToBind                                = "foundry.spark.scheduler.reservations.timetobind"
+	timeToBindP50                             = "foundry.spark.scheduler.reservations.timetobind.p50"
 	softReservationCount                      = "foundry.spark.scheduler.softreservation.count"
 	softReservationExecutorCount              = "foundry.spark.scheduler.softreservation.executorcount"
 	executorsWithNoReservationCount           = "foundry.spark.scheduler.softreservation.executorswithnoreservations"
@@ -363,4 +365,11 @@ func (dct *SoftReservationCompactionTimer) MarkCompactionComplete(ctx context.Co
 // IncrementSingleAzDynamicAllocationPackFailure increments a counter for a zone we fail to schedule in, this allows us to keep track of exactly which zones are over utilised
 func IncrementSingleAzDynamicAllocationPackFailure(ctx context.Context, zone string) {
 	metrics.FromContext(ctx).Counter(singleAzDynamicAllocationPackFailureCount, ZoneTag(ctx, zone)).Inc(1)
+}
+
+// ReportTimeToBindMetrics reports how long it takes between a reservation being created and pods being bound to said reservation.
+func ReportTimeToBindMetrics(ctx context.Context, durationMicros int64) {
+	timeToBindHist := metrics.FromContext(ctx).Histogram(timeToBind)
+	timeToBindHist.Update(durationMicros)
+	metrics.FromContext(ctx).GaugeFloat64(timeToBindP50).Update(timeToBindHist.Mean())
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -368,8 +368,8 @@ func IncrementSingleAzDynamicAllocationPackFailure(ctx context.Context, zone str
 	metrics.FromContext(ctx).Counter(singleAzDynamicAllocationPackFailureCount, ZoneTag(ctx, zone)).Inc(1)
 }
 
-// ReportTimeToBindMetrics reports how long it takes between a reservation being created and pods being bound to said reservation.
-func ReportTimeToBindMetrics(ctx context.Context, duration time.Duration) {
+// ReportTimeToFirstBindMetrics reports how long it takes between a reservation being created and pods being bound to said reservation.
+func ReportTimeToFirstBindMetrics(ctx context.Context, duration time.Duration) {
 	timeToFirstBindHist := metrics.FromContext(ctx).Histogram(timeToFirstBind)
 	timeToFirstBindHist.Update(duration.Nanoseconds())
 	metrics.FromContext(ctx).GaugeFloat64(timeToFirstBindP50).Update(timeToFirstBindHist.Percentile(.5))

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -370,8 +370,8 @@ func IncrementSingleAzDynamicAllocationPackFailure(ctx context.Context, zone str
 
 // ReportTimeToBindMetrics reports how long it takes between a reservation being created and pods being bound to said reservation.
 func ReportTimeToBindMetrics(ctx context.Context, duration time.Duration) {
-	timeToBindHist := metrics.FromContext(ctx).Histogram(timeToFirstBind)
-	timeToBindHist.Update(duration.Nanoseconds())
-	metrics.FromContext(ctx).GaugeFloat64(timeToFirstBindP50).Update(timeToBindHist.Percentile(.5))
-	metrics.FromContext(ctx).GaugeFloat64(timeToFirstBindMean).Update(timeToBindHist.Mean())
+	timeToFirstBindHist := metrics.FromContext(ctx).Histogram(timeToFirstBind)
+	timeToFirstBindHist.Update(duration.Nanoseconds())
+	metrics.FromContext(ctx).GaugeFloat64(timeToFirstBindP50).Update(timeToFirstBindHist.Percentile(.5))
+	metrics.FromContext(ctx).GaugeFloat64(timeToFirstBindMean).Update(timeToFirstBindHist.Mean())
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -52,9 +52,9 @@ const (
 	unboundCPUReservations                    = "foundry.spark.scheduler.reservations.unbound.cpu"
 	unboundMemoryReservations                 = "foundry.spark.scheduler.reservations.unbound.memory"
 	unboundNvidiaGPUReservations              = "foundry.spark.scheduler.reservations.unbound.nvidiagpu"
-	timeToBind                                = "foundry.spark.scheduler.reservations.timetobind"
-	timeToBindP50                             = "foundry.spark.scheduler.reservations.timetobind.p50"
-	timeToBindMean                            = "foundry.spark.scheduler.reservations.timetobind.mean"
+	timeToFirstBind                           = "foundry.spark.scheduler.reservations.timetofirstbind"
+	timeToFirstBindP50                        = "foundry.spark.scheduler.reservations.timetofirstbind.p50"
+	timeToFirstBindMean                       = "foundry.spark.scheduler.reservations.timetofirstbind.mean"
 	softReservationCount                      = "foundry.spark.scheduler.softreservation.count"
 	softReservationExecutorCount              = "foundry.spark.scheduler.softreservation.executorcount"
 	executorsWithNoReservationCount           = "foundry.spark.scheduler.softreservation.executorswithnoreservations"
@@ -370,8 +370,8 @@ func IncrementSingleAzDynamicAllocationPackFailure(ctx context.Context, zone str
 
 // ReportTimeToBindMetrics reports how long it takes between a reservation being created and pods being bound to said reservation.
 func ReportTimeToBindMetrics(ctx context.Context, duration time.Duration) {
-	timeToBindHist := metrics.FromContext(ctx).Histogram(timeToBind)
-	timeToBindHist.Update(duration.Microseconds())
-	metrics.FromContext(ctx).GaugeFloat64(timeToBindP50).Update(timeToBindHist.Percentile(.5))
-	metrics.FromContext(ctx).GaugeFloat64(timeToBindMean).Update(timeToBindHist.Mean())
+	timeToBindHist := metrics.FromContext(ctx).Histogram(timeToFirstBind)
+	timeToBindHist.Update(duration.Nanoseconds())
+	metrics.FromContext(ctx).GaugeFloat64(timeToFirstBindP50).Update(timeToBindHist.Percentile(.5))
+	metrics.FromContext(ctx).GaugeFloat64(timeToFirstBindMean).Update(timeToBindHist.Mean())
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -54,6 +54,7 @@ const (
 	unboundNvidiaGPUReservations              = "foundry.spark.scheduler.reservations.unbound.nvidiagpu"
 	timeToBind                                = "foundry.spark.scheduler.reservations.timetobind"
 	timeToBindP50                             = "foundry.spark.scheduler.reservations.timetobind.p50"
+	timeToBindMean                            = "foundry.spark.scheduler.reservations.timetobind.mean"
 	softReservationCount                      = "foundry.spark.scheduler.softreservation.count"
 	softReservationExecutorCount              = "foundry.spark.scheduler.softreservation.executorcount"
 	executorsWithNoReservationCount           = "foundry.spark.scheduler.softreservation.executorswithnoreservations"
@@ -368,8 +369,9 @@ func IncrementSingleAzDynamicAllocationPackFailure(ctx context.Context, zone str
 }
 
 // ReportTimeToBindMetrics reports how long it takes between a reservation being created and pods being bound to said reservation.
-func ReportTimeToBindMetrics(ctx context.Context, durationMicros int64) {
+func ReportTimeToBindMetrics(ctx context.Context, duration time.Duration) {
 	timeToBindHist := metrics.FromContext(ctx).Histogram(timeToBind)
-	timeToBindHist.Update(durationMicros)
+	timeToBindHist.Update(duration.Microseconds())
 	metrics.FromContext(ctx).GaugeFloat64(timeToBindP50).Update(timeToBindHist.Percentile(.5))
+	metrics.FromContext(ctx).GaugeFloat64(timeToBindMean).Update(timeToBindHist.Mean())
 }


### PR DESCRIPTION
## Before this PR

#250 helps quantify how many resources are taken by unbound reservations, however it doesn't help us understand how long reservation stay unbound.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add time to bind metrics
==COMMIT_MSG==

## Possible downsides?

This doesn't capture reservations that never get bound, but that shouldn't really happen under normal circumstances.
