### PR TITLE
Rename p50 to median, attempt to address duration overflow

### DIFF
--- a/internal/extender/resourcereservations.go
+++ b/internal/extender/resourcereservations.go
@@ -341,8 +341,11 @@ func (rrm *ResourceReservationManager) bindExecutorToResourceReservation(ctx con
 	if _, ok := resourceReservation.Status.Pods[reservationName]; !ok {
 		// this is the k8s server time, so the duration we're computing only makes sense if clocks are reasonably kept in sync
 		creationTime := resourceReservation.CreationTimestamp.Time
-		duration := time.Now().Sub(creationTime)
-		metrics.ReportTimeToFirstBindMetrics(ctx, duration)
+
+		if !creationTime.IsZero() {
+			duration := time.Since(creationTime)
+			metrics.ReportTimeToFirstBindMetrics(ctx, duration)
+		}
 	}
 	return nil
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -53,7 +53,7 @@ const (
 	unboundMemoryReservations                 = "foundry.spark.scheduler.reservations.unbound.memory"
 	unboundNvidiaGPUReservations              = "foundry.spark.scheduler.reservations.unbound.nvidiagpu"
 	timeToFirstBind                           = "foundry.spark.scheduler.reservations.timetofirstbind"
-	timeToFirstBindP50                        = "foundry.spark.scheduler.reservations.timetofirstbind.p50"
+	timeToFirstBindMedian                     = "foundry.spark.scheduler.reservations.timetofirstbind.median"
 	timeToFirstBindMean                       = "foundry.spark.scheduler.reservations.timetofirstbind.mean"
 	softReservationCount                      = "foundry.spark.scheduler.softreservation.count"
 	softReservationExecutorCount              = "foundry.spark.scheduler.softreservation.executorcount"
@@ -372,6 +372,6 @@ func IncrementSingleAzDynamicAllocationPackFailure(ctx context.Context, zone str
 func ReportTimeToFirstBindMetrics(ctx context.Context, duration time.Duration) {
 	timeToFirstBindHist := metrics.FromContext(ctx).Histogram(timeToFirstBind)
 	timeToFirstBindHist.Update(duration.Nanoseconds())
-	metrics.FromContext(ctx).GaugeFloat64(timeToFirstBindP50).Update(timeToFirstBindHist.Percentile(.5))
+	metrics.FromContext(ctx).GaugeFloat64(timeToFirstBindMedian).Update(timeToFirstBindHist.Percentile(.5))
 	metrics.FromContext(ctx).GaugeFloat64(timeToFirstBindMean).Update(timeToFirstBindHist.Mean())
 }


### PR DESCRIPTION
## Before this PR

* `.p50` metric is filtered out and does not make it to our observability tooling, renaming it to `.median` instead
* the metrics seem to overflow, it's a bit unclear but a first attempt at a fix is to ignore `CreationTimestamp` is the zero value (it's unclear when this would actually happen, looking at `kubectl get rr -A -o yaml` that doesn't seem to be the case, maybe an unmarshalling issue between the k8s api server and our clients?).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Rename p50 to median, attempt to address duration overflow
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
