### PR TITLE
improvement: Move the ResourceReservationManager to an interface downstream clients can mock it

### DIFF
--- a/internal/extender/overhead.go
+++ b/internal/extender/overhead.go
@@ -32,7 +32,7 @@ import (
 // OverheadComputer computes non spark scheduler managed pods total resources periodically
 type OverheadComputer struct {
 	podInformer                coreinformers.PodInformer
-	resourceReservationManager *ResourceReservationManager
+	resourceReservationManager ResourceReservationManager
 	resourceRequests           ClusterRequests
 	nodeLister                 corelisters.NodeLister
 	overheadLock               *sync.RWMutex
@@ -56,7 +56,7 @@ type PodRequestInfo struct {
 func NewOverheadComputer(
 	ctx context.Context,
 	podInformer coreinformers.PodInformer,
-	resourceReservationManager *ResourceReservationManager,
+	resourceReservationManager ResourceReservationManager,
 	nodeLister corelisters.NodeLister) *OverheadComputer {
 	computer := &OverheadComputer{
 		podInformer:                podInformer,

--- a/internal/extender/resource.go
+++ b/internal/extender/resource.go
@@ -65,7 +65,7 @@ type SparkSchedulerExtender struct {
 	podLister                  *SparkPodLister
 	resourceReservations       *cache.ResourceReservationCache
 	softReservationStore       *cache.SoftReservationStore
-	resourceReservationManager *ResourceReservationManager
+	resourceReservationManager ResourceReservationManager
 	coreClient                 corev1.CoreV1Interface
 	nodeSorter                 *ns.NodeSorter
 
@@ -89,7 +89,7 @@ func NewExtender(
 	podLister *SparkPodLister,
 	resourceReservations *cache.ResourceReservationCache,
 	softReservationStore *cache.SoftReservationStore,
-	resourceReservationManager *ResourceReservationManager,
+	resourceReservationManager ResourceReservationManager,
 	coreClient corev1.CoreV1Interface,
 	demands *cache.SafeDemandCache,
 	apiExtensionsClient apiextensionsclientset.Interface,


### PR DESCRIPTION
- Move the ResourceReservationManager to an interface downstream clients can mock it 
- Right now demand manipulation are a combination of static methods and using the raw SafeDemandCache struct which makes it impossible to test or mock
- This moves this operations behind a single interface
- Noop
- Similar to https://github.com/palantir/k8s-spark-scheduler/pull/255

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
