### PR TITLE
Set CreationTimestamp for newly created resource reservations

### DIFF
--- a/internal/extender/resourcereservations.go
+++ b/internal/extender/resourcereservations.go
@@ -339,10 +339,15 @@ func (rrm *ResourceReservationManager) bindExecutorToResourceReservation(ctx con
 
 	// only report the metric the first time the reservation is bound
 	if _, ok := resourceReservation.Status.Pods[reservationName]; !ok {
-		// this is the k8s server time, so the duration we're computing only makes sense if clocks are reasonably kept in sync
+		// this should the k8s server time, but due to the way we cache request/object this might actually be set by k8s-spark-scheduler itself
 		creationTime := resourceReservation.CreationTimestamp.Time
-		duration := time.Now().Sub(creationTime)
-		metrics.ReportTimeToFirstBindMetrics(ctx, duration)
+
+		// we haven't observed this in practice, but the docs for CreationTimestamp make it clear that this is optional
+		// so just to be safe we ignore the zero-value
+		if !creationTime.IsZero() {
+			duration := time.Since(creationTime)
+			metrics.ReportTimeToFirstBindMetrics(ctx, duration)
+		}
 	}
 	return nil
 }
@@ -469,9 +474,10 @@ func newResourceReservation(driverNode string, executorNodes []string, driver *v
 	}
 	return &v1beta2.ResourceReservation{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            driver.Labels[common.SparkAppIDLabel],
-			Namespace:       driver.Namespace,
-			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(driver, podGroupVersionKind)},
+			Name:              driver.Labels[common.SparkAppIDLabel],
+			Namespace:         driver.Namespace,
+			OwnerReferences:   []metav1.OwnerReference{*metav1.NewControllerRef(driver, podGroupVersionKind)},
+			CreationTimestamp: metav1.Now(),
 			Labels: map[string]string{
 				v1beta1.AppIDLabel: driver.Labels[common.SparkAppIDLabel],
 			},


### PR DESCRIPTION
Fixes #257

`CreationTimestamp` is meant to be (optionally) set by the server, however due to how k8s-spark-scheduler works currently we never get to see the value that k8s assigns to it.

The underlying reason lies in the fact that https://github.com/palantir/k8s-spark-scheduler/blob/a7122ad7c79f607960bcf44e910bee8ad04a2810/internal/cache/cache.go#L29-L31 purposely does not reflect 'outside' updates, which for most intent and purposes isn't an issue, except when we try to rely on the k8s api server setting `CreationTimestamp`.

So instead, we now always set `CreationTimestamp` when creating a new resource reservation, which is turn is going to be ignored by k8s, but it allows us to properly track the metric we introduced in https://github.com/palantir/k8s-spark-scheduler/pull/256, w/o this, we observe that the metric is useless (`CreationTimestamp` defaults to the zero value for `meta1.Time`, which in turns means the duration we're measuring overflows).

## After this PR
==COMMIT_MSG==
Set CreationTimestamp for newly created resource reservations
==COMMIT_MSG==

## Possible downsides?

This isn't the cleanest option, but it's a bit unclear whether changing https://github.com/palantir/k8s-spark-scheduler/blob/a7122ad7c79f607960bcf44e910bee8ad04a2810/internal/cache/store/store.go#L29 in favour of a new `OverrideResourceVersionIfNewerOrEqual` would have unforeseen consequences. In addition, this would that solution would yield more occurrences of `CreationTimestamp` being zero-valued.

Additionally this PR only solves the issue for resource reservations and not other CRDs (e.g. demands) since, at least for now, we do not rely on their `CreationTimestamp`.
